### PR TITLE
Switch back to UBI and pin RHEL version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
+ARG RHEL_VERSION=9.4
+FROM registry.redhat.io/ubi9/ubi-minimal:${RHEL_VERSION}
+ARG RHEL_VERSION
 
 LABEL com.redhat.component="dpdk-base-container" \
     name="dpdk-base" \
@@ -48,9 +50,16 @@ RUN INSTALL_PKGS="bsdtar \
   expect" && \
   mkdir -p ${HOME}/.pki/nssdb && \
   chown -R 1001:0 ${HOME}/.pki && \
-  microdnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  microdnf --setopt=tsflags=nodocs -y install subscription-manager && \
+  subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey") && \
+  subscription-manager release --set=${RHEL_VERSION} && \
+  microdnf --disablerepo=* --enablerepo=*eus-rpms* makecache || DISABLED_EUS_REPOS="--disablerepo=*eus-rpms*" && \
+  sed -i 's/enabled *= *1/enabled=0/g' /etc/yum.repos.d/ubi.repo && \
+  microdnf $DISABLED_EUS_REPOS --setopt=tsflags=nodocs -y distro-sync && \
+  microdnf $DISABLED_EUS_REPOS --setopt=tsflags=nodocs -y install $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
-  microdnf -y clean all --enablerepo='*'
+  microdnf -y clean all --enablerepo='*' && \
+  subscription-manager unregister
 
 # in dpdk 20.11 the testpmd bin changed to dpdk-testpmd
 # for backport support we add a symlink


### PR DESCRIPTION
The container image should be based on the same RHEL version OCP is. For example, OCP 4.18 is RHEL 9.4 EUS and OCP 4.19 will be on RHEL 9.6 at some point later. Use the `RHEL_VERSION` argument to override if needed.

Subscription manager is required for enabling EUS RPM repositories (e.g. 9.4 EUS) -- we want that for critical bug and CVE fixes. For non-EUS releases, we MUST disable EUS repositories or else microdnf will fail. Do so by refreshing the cache with only EUS repositories enabled -- if that fails, it means the base image is non-EUS RHEL.

However, installing subscription-manager will come from UBI repositories which point to latest RHEL y-version which may not be our desired y-version (e.g. 9.5 (latest) vs 9.4). Run `distro-sync` to align RPMs.