### PR TITLE
Update base image to RHEL 9.6 ELS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal:9.4
+FROM registry.redhat.io/rhel9-6-els/rhel-minimal:9.6
 
 LABEL com.redhat.component="dpdk-base-container" \
     name="dpdk-base" \

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -4,2459 +4,2445 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/b/bsdtar-3.5.3-4.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/b/bsdtar-3.5.3-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 66320
     checksum: sha256:ea360e40d326d2a629ba085da403e6d4cd78ce57fda1f9db308202c2bee17edf
     name: bsdtar
     evr: 3.5.3-4.el9
     sourcerpm: libarchive-3.5.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/e/expect-5.45.4-16.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 10795955
+    checksum: sha256:fd6561d7ca6a5ec7a9d9c17c623d97c24eec8f6c8de91081ba95343ebd0de7c2
+    name: cpp
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/d/dpdk-24.11.1-2.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 1672519
+    checksum: sha256:c11021fbf2879a2c4ab620e2ced98277ab0d9a8eea75bb6a26eb9579ae7605cc
+    name: dpdk
+    evr: 2:24.11.1-2.el9
+    sourcerpm: dpdk-24.11.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/d/dpdk-devel-24.11.1-2.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 4544329
+    checksum: sha256:d38e0d5b5cf182b54036f0b25758a657f560e63c2fb5f188adad4f8871e4b963
+    name: dpdk-devel
+    evr: 2:24.11.1-2.el9
+    sourcerpm: dpdk-24.11.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/d/dpdk-tools-24.11.1-2.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 35411
+    checksum: sha256:8ea37f237d77079298f181dc7097db28a59e1f1a8c9a70923cf9ae0b411af076
+    name: dpdk-tools
+    evr: 2:24.11.1-2.el9
+    sourcerpm: dpdk-24.11.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-13.el9_6.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 9758
+    checksum: sha256:624b6683efb3e254eb8f44a927772ec251a841803b7f693f9c6ad0651e694557
+    name: emacs-filesystem
+    evr: 1:27.2-13.el9_6
+    sourcerpm: emacs-27.2-13.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/e/expect-5.45.4-16.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 263489
     checksum: sha256:bb6ef24b21b92ae2ef33f74078d61e346755f1fac970ff4f99a0c030d4033ad0
     name: expect
     evr: 5.45.4-16.el9
     sourcerpm: expect-5.45.4-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/gcc-11.5.0-5.el9_5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 31300907
+    checksum: sha256:0adab9938458e552e3d5433c668d7abb946be0a81b2b510a201136efbca51601
+    name: gcc
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/git-2.47.1-2.el9_6.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 55457
+    checksum: sha256:6fe253ad5859c4d2b617dca0f658e87eef9369b0c2240c1e3129dd2aecc02cdd
+    name: git
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/git-core-2.47.1-2.el9_6.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 5042227
+    checksum: sha256:99e42a9a19e5eac7f1480b33dfb660d66e81e314b731eee6c8354b0146254b4a
+    name: git-core
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/git-core-doc-2.47.1-2.el9_6.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 3194257
+    checksum: sha256:172dd65142fcd6548658a47e46d06a9a80251ab7a2cd6da6a0a99bb92e83cb56
+    name: git-core-doc
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.14.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 564233
+    checksum: sha256:3599f22ae4ad64bf0e5e279f584fb63374d96e63c0acf84a27ff00949f2606ca
+    name: glibc-devel
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/g/glibc-locale-source-2.34-168.el9_6.14.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 4357743
+    checksum: sha256:ad98ffc8c8aa26cd96af34e16e87e1310827731ce416eccaebc75e4783b5defc
+    name: glibc-locale-source
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-570.17.1.el9_6.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 3642217
+    checksum: sha256:20559facc5fadbe8e756240e4afc65252ce3fad4cd9b06d0fea5b594ca76d427
+    name: kernel-headers
+    evr: 5.14.0-570.17.1.el9_6
+    sourcerpm: kernel-5.14.0-570.17.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libarchive-devel-3.5.3-4.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 138612
+    checksum: sha256:0dffdaf496bd0bb1b320be053b6366f0fcb522e59d27301bd76e26c95925ba78
+    name: libarchive-devel
+    evr: 3.5.3-4.el9
+    sourcerpm: libarchive-3.5.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libasan-11.5.0-5.el9_5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 413819
+    checksum: sha256:3febfe157847f68e8c94796eb4a0e2d4c3c660b33c91ad068dd75f785ae76fa0
+    name: libasan
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 67120
     checksum: sha256:3763354a5f45d886f9976eec20eb34f8afc2144c69ffba07de546f2820893c70
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libubsan-11.5.0-5.el9_5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 183667
+    checksum: sha256:0751fe4ed4571b48dbca8664a16b410030ec76e2f5d71234807751458d717f31
+    name: libubsan
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 33051
     checksum: sha256:9d621f33df35b9c274b8d65457d6c67fc1522b6c62cf7b2341a4a99f39a93507
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 21821
     checksum: sha256:52cda881960f48be35a47ba1c54f242efac1ab0d1fd74b0e2bcb48a1723907c8
     name: perl-AutoLoader
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-B-1.80-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-B-1.80-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 188904
     checksum: sha256:78fa2f2d5ac4356a7f46d888aebd31e52da12553f8fd6a6636c24b5eaa670feb
     name: perl-B
     evr: 1.80-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 22914
     checksum: sha256:45347749c36c4750c9083d4784700fb85c3a4c277c3bf69873a1c6ae97ee6c4b
     name: perl-Class-Struct
     evr: 0.66-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 58773
     checksum: sha256:0ac738aff66419ff8853d2e2b8d2fe231b90de129060ecc0390bca9c6c680e0d
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 40515
     checksum: sha256:6eeb8e68cfbd7cca24d6132be8b947de99ab26cdb79d6021e9e6efeb36b67e0b
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 26374
     checksum: sha256:38bf98dd2b3e6030058fb3a358e82753da85de8d8a6ad58f7502344444fac451
     name: perl-DynaLoader
     evr: 1.47-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 1825541
     checksum: sha256:72c92a12c67d05f9aa7f5670ccb1b743612d8fa946775feada28e199a31db0a9
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 15285
     checksum: sha256:12b6bcda3a1fdb139e09ef44887a3e068fcdd42afaf9dd4c82b12a8aa3e74724
     name: perl-Errno
     evr: 1.30-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 47552
     checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
     name: perl-Error
     evr: 1:0.17029-7.el9
     sourcerpm: perl-Error-0.17029-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 21959
     checksum: sha256:6a4cfcc9fc505983315f543068fdb83b3dc13aada8b2da9a41fa049bc4f0ac09
     name: perl-Fcntl
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 17916
     checksum: sha256:746f919f1aebc91a28f00e20eda7b41991db9e50abf2fa22cd7f8168a8f9898a
     name: perl-File-Basename
     evr: 2.85-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 26277
     checksum: sha256:e388937b023c024de285a5b50fe3f44722c18207d7d854aff302f4ad3c8742f4
     name: perl-File-Find
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 17853
     checksum: sha256:355aba30d043f829e4e7e70466564ba85f65f7a2416aba0ceddfc9e59288aab4
     name: perl-File-stat
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 15921
     checksum: sha256:480ac4c1de2c1e1f94ed8895793b93d96bd50dc95e6e4fa9c39a82a24998f717
     name: perl-FileHandle
     evr: 2.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 16222
     checksum: sha256:c9c6209474ec44ca5b070ffb147589359c551757f95b358a8f35d2627c4950cf
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Git-2.47.1-2.el9_6.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 40089
+    checksum: sha256:3bb2b9b3f197bb548455a5ed7304ef25510f4ae6f4ee92dd4db74946a869442e
+    name: perl-Git
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-IO-1.43-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IO-1.43-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 94579
     checksum: sha256:be88a2f06f958b9ce3d407c8db3833de0766eb998a06eedab4670db9878e061e
     name: perl-IO
     evr: 1.43-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 228493
-    checksum: sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f
+    size: 226003
+    checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
-    evr: 2.073-1.el9
-    sourcerpm: perl-IO-Socket-SSL-2.073-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
+    evr: 2.073-2.el9
+    sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 24124
     checksum: sha256:422c83bcdd2f84d9751fe4ea289e6bc8bfbc41e6540d6482671317fbc2ff1a17
     name: perl-IPC-Open3
     evr: 1.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 35080
     checksum: sha256:8fd71ba1ada7ab6b0b83400716671139a7adbf01d9bfed881398497170ccb308
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 23492
     checksum: sha256:ab4a9be46c64b83524f9b5169d88f025c22ecefb37d81f2e8c13df134c7158c4
     name: perl-NDBM_File
     evr: 1.15-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Net-SSLeay-1.92-2.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 402355
-    checksum: sha256:66d81ac0dbee551b3fd92da3655a1e96c80b8aeaebfb21936b4496bb7022a5b0
+    size: 429301
+    checksum: sha256:8f46470e0e2a76d1f534b8d0d607d84a64ebfab3df8347bae2d52d113c8d54eb
     name: perl-Net-SSLeay
-    evr: 1.92-2.el9
-    sourcerpm: perl-Net-SSLeay-1.92-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.aarch64.rpm
+    evr: 1.94-1.el9
+    sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 100314
     checksum: sha256:3b83ed6478d8f143547f9ecd284b3139d6f25698cc4466729a55b0d8a3b9ac9e
     name: perl-POSIX
     evr: 1.94-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 94325
     checksum: sha256:5cd800158be7a9ddaf8e9c5d193d10992e01a35c4f438ff072852d194e3a5311
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-461.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 77570
-    checksum: sha256:edba405ffdc10fd37963b690b43f25abde8d171f5c8631b353a8d146f7538eca
+    size: 76001
+    checksum: sha256:5e3592356c1610311f5bf8be4cbc9e35ad04d6b3ba089d70b700d8b70f534635
     name: perl-Scalar-List-Utils
-    evr: 4:1.56-461.el9
-    sourcerpm: perl-Scalar-List-Utils-1.56-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
+    evr: 4:1.56-462.el9
+    sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 12017
     checksum: sha256:c4f02fdf5b501ab67b4824fc4473ba420f482254ad82e90b546d9b10a5464820
     name: perl-SelectSaver
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 59426
     checksum: sha256:f69c6cd2c48606efa7477ef73ef2cb03c07aa02d535f03824dbe966f6235cc88
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 98115
     checksum: sha256:61a7bc7d2a2e3b0c42289927a1ecc7b9f672ce3281be58a59b3b2875e4203457
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 14535
     checksum: sha256:2364cd3b0a19572b16a1379c228046a405851bcd0676860a6aeb9bcb3869498f
     name: perl-Symbol
     evr: 1.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 40577
     checksum: sha256:bfe0d10d4c1028a7929ca213bfd3871f059ea0daeec4c48f3e85d54d77a5a2fc
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 16674
     checksum: sha256:dab1d27f285d579c9783e80817f98a2835e7bf06842d704a7f85cfdb7ab4b0a3
     name: perl-base
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 14343
     checksum: sha256:714022b8937ed9c6d4638b99aef0a8426b782e7948019b50b06d9cd2e32e454a
     name: perl-if
     evr: 0.60.800-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 74626
     checksum: sha256:676044af96202c9ed74003323f3d1fbb76a46dc82c0eeb5382fe03870b3aff8f
     name: perl-interpreter
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-lib-0.65-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-lib-0.65-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 15272
     checksum: sha256:86725f96c996c2db85324e939da020c7e587570ecf1f541e9ad38dee984419b3
     name: perl-lib
     evr: 0.65-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 2263056
     checksum: sha256:7a46669305e11ed69be2434badbaede68ccd0b6576ef11bc0cc7c03df6ab658f
     name: perl-libs
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-mro-1.23-481.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-mro-1.23-481.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 29462
     checksum: sha256:0afcac4067601e057accf67f9cf80b95f441ad1c5260c32864da54da2f83612e
     name: perl-mro
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 46643
     checksum: sha256:813598b9d9a3ada4975144cf0dd0f25906589a92c7708556dcbf464501d72848
     name: perl-overload
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 13658
     checksum: sha256:feca093162af099f769448e95170a357f2d2bd66da36299d1a999782d57da51d
     name: perl-overloading
     evr: 0.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 11986
     checksum: sha256:df6327eb3774c2254fc45c630cedf3b32b3bdd7f146bf25ffe0342f9904dac43
     name: perl-subs
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 13347
     checksum: sha256:c54caddd2a5adaf84088833a9eb126e772b6db090800c3293b819f432ddd6b6c
     name: perl-vars
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-29.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 18201
-    checksum: sha256:586b32b05d9dcbb99a077905bd85ecb3ccf0ba1b0412a6ec55024b7756e51453
+    size: 10730
+    checksum: sha256:d835fd578f8ebf17c5914a4d8695ca78e68676880b690dd2a322b541a2897a71
+    name: python-unversioned-command
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-37.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 18006
+    checksum: sha256:de76034748e9be22ae21e34b57a3885c98269574dea024fc581307abb225165c
     name: rpm-plugin-systemd-inhibit
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.aarch64.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 42050
     checksum: sha256:b7c093e050e3d127b98bd1002e46dee9cfbbc6279978aee17d7fad30b42a41ec
     name: scl-utils
     evr: 1:2.0.3-4.el9
     sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/a/acl-2.3.1-4.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/a/acl-2.3.1-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 77245
     checksum: sha256:59d24711260ff0e69762fc4e728279b0e7b6ecfdb5a9b8ba01cd96682c679022
     name: acl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/b/binutils-2.35.2-43.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/a/attr-2.5.1-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 5024988
-    checksum: sha256:8cf5a3b2ede33c41bc1cda6b08efbc31082143fd891b24272ec5d3ebbe9be8fb
+    size: 66448
+    checksum: sha256:e86457936847a358b068f4f235800fb507d44321e65814f579355c4e46f85941
+    name: attr
+    evr: 2.5.1-3.el9
+    sourcerpm: attr-2.5.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/b/binutils-2.35.2-63.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 5023899
+    checksum: sha256:c0daaed62bf2dc4ff0f3a30e3f0c538170c998c2b805acf931b7e8b77accf087
     name: binutils
-    evr: 2.35.2-43.el9
-    sourcerpm: binutils-2.35.2-43.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-43.el9.aarch64.rpm
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 904090
-    checksum: sha256:0ed5890c34b47c8926273f254013e6b7decb6f306d4569b75a775c1ffb56fd7d
+    size: 903496
+    checksum: sha256:71c324de618542f894eb113644b2082d2f0e8d648d31a32f8a5fe14a78a5d295
     name: binutils-gold
-    evr: 2.35.2-43.el9
-    sourcerpm: binutils-2.35.2-43.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.aarch64.rpm
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 100995
     checksum: sha256:6b4e2bae51af42c1ab0f1ec7430ab19542747937a827eba8cac540cb7514a145
     name: cracklib
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 3821337
     checksum: sha256:c4ef55b06c9b5352b2338a6deccd25030472308b3ffe39735585967382e75419
     name: cracklib-dicts
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/d/dbus-1.12.20-8.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/d/dbus-1.12.20-8.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 8025
     checksum: sha256:5178f638660d1699fb06caeeac91f41c07da59b500e94adf2653df892f2cbdf8
     name: dbus
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/d/dbus-broker-28-7.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/d/dbus-broker-28-7.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 173303
     checksum: sha256:342af53fbf4254e34b5f19a6be6f22c67551c26dd0c49016edc93e806621b75d
     name: dbus-broker
     evr: 28-7.el9
     sourcerpm: dbus-broker-28-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 18551
     checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
     name: dbus-common
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/d/dbus-libs-1.12.20-8.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/d/dbus-libs-1.12.20-8.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 154779
     checksum: sha256:d169ddf3a47520e5f73d4edb64e845910aa9ab48e0d0206e4a92a9f882f21882
     name: dbus-libs
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/d/diffutils-3.7-12.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/d/dnf-4.14.0-25.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 405687
-    checksum: sha256:524412f7ce56095508190116cb8ae141737857e4447979330c3cf75ca7017e6b
-    name: diffutils
-    evr: 3.7-12.el9
-    sourcerpm: diffutils-3.7-12.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/d/dnf-4.14.0-9.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 497541
-    checksum: sha256:600d1feac9337bd6d9a65a09f892b4a42651b5bea03da908ab2db63eab315cb1
+    size: 494210
+    checksum: sha256:b13e385796f68e45acf995bf9faa38bbf23f87b56135245244b711b89c58b485
     name: dnf
-    evr: 4.14.0-9.el9
-    sourcerpm: dnf-4.14.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.190-2.el9.aarch64.rpm
+    evr: 4.14.0-25.el9
+    sourcerpm: dnf-4.14.0-25.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.192-5.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 39099
-    checksum: sha256:2f16ac3a350091ea2517dae53b8cad48f6fb76070d50d7f0f6dff6042f2563fd
+    size: 46032
+    checksum: sha256:74270832db29a34811e88a3756b0ab509354d9bbbcf71f01640d65cefbfadfac
     name: elfutils-debuginfod-client
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.190-2.el9.noarch.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.192-5.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 12538
-    checksum: sha256:26aaebd8f1b36f55622d5376e79cdee9da0a69ca45dc6747a8828db4b0c1d24c
+    size: 9839
+    checksum: sha256:fb2fe6a8f7552aecda6c998adddb0f88264252b6f717a306adfd0c24b0e33e79
     name: elfutils-default-yama-scope
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/e/elfutils-libelf-0.190-2.el9.aarch64.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/e/elfutils-libelf-0.192-5.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 199708
-    checksum: sha256:d15c0fe342474417e47f26edeb11be007a15928f7ea0a3e1cdec6a267623b9cc
+    size: 211706
+    checksum: sha256:6b3ef2b8e3dfe144aa7f46438f0729ff7fa0ef6ec4ad687593838426cc0406da
     name: elfutils-libelf
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/e/elfutils-libs-0.190-2.el9.aarch64.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/e/elfutils-libs-0.192-5.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 262713
-    checksum: sha256:1da3fe6f24532a691297523a56bfbc4ddb931d0c2391d24711b083beb1470ece
+    size: 268474
+    checksum: sha256:3d3f52fb89e3f927beca1ffbb28c84cb8bdec2fec7b0d3c080142ec225395bd2
     name: elfutils-libs
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/e/environment-modules-5.3.0-1.el9.aarch64.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/e/environment-modules-5.3.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 606222
     checksum: sha256:262f6a3b7147bba3d3eb9460fdd56fdd5602bf810eefffe03d207197acf1f39f
     name: environment-modules
     evr: 5.3.0-1.el9
     sourcerpm: environment-modules-5.3.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/f/findutils-4.8.0-6.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 564221
-    checksum: sha256:dd033c668c1378da304bcd2acb28ab749bf3cac8daa37a197c94aed5943be872
+    size: 116016
+    checksum: sha256:fd3234795b06ce0a45bfdec417be51a88296c0da0ea5b0d156aa327839e33052
+    name: expat
+    evr: 2.5.0-5.el9_6
+    sourcerpm: expat-2.5.0-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/f/findutils-4.8.0-7.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 564807
+    checksum: sha256:158af4d5ecbd8b87f0da762ea1655bd4c86512071a95d8307eda3e0b3991105d
     name: findutils
-    evr: 1:4.8.0-6.el9
-    sourcerpm: findutils-4.8.0-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/gettext-0.21-8.el9.aarch64.rpm
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/gettext-0.21-8.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 1181385
     checksum: sha256:52f11ec908a17fedbf993ffd87f40f27067761440c433b0d0fd38f16b8d15ec4
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 295874
     checksum: sha256:b503ae5eaa875c8936ac6c28dec058d0febc6ce072c0046028bc471a37607f6a
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 1088949
     checksum: sha256:452cfe5372c834bb174ef1f6eed4d0aa6179420fd572163467ac9036fc7a3a1d
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 169809
     checksum: sha256:45710df49b439ddc4a2848fd3877367761b574234ae28b6be46f1cf54f3fcdca
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/h/hwdata-0.348-9.13.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/h/hwdata-0.348-9.18.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 1674692
-    checksum: sha256:c6dd3fc36960df2631bb2cc55d5a9fc431d882ba91336f5f3aef17c15c12b8a7
+    size: 1724460
+    checksum: sha256:3f50d2d645126aab5407531cdfa813544c85c44d312bc19dcc3378460b9eb03d
     name: hwdata
-    evr: 0.348-9.13.el9
-    sourcerpm: hwdata-0.348-9.13.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/i/ima-evm-utils-1.4-4.el9.aarch64.rpm
+    evr: 0.348-9.18.el9
+    sourcerpm: hwdata-0.348-9.18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/i/ima-evm-utils-1.5-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 68519
-    checksum: sha256:9df855d4aa662aed90c1e7d219cf34fa63ce8e556729e5b3c536661b7e4e1a32
+    size: 74672
+    checksum: sha256:12508120fe3fa4b70b12bbfb6e9d3ea7b09decfac0e59ddffc7c1fe7f57c50d7
     name: ima-evm-utils
-    evr: 1.4-4.el9
-    sourcerpm: ima-evm-utils-1.4-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/i/iproute-6.2.0-6.el9_4.aarch64.rpm
+    evr: 1.5-3.el9
+    sourcerpm: ima-evm-utils-1.5-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/i/iproute-6.11.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 843826
-    checksum: sha256:e66c30ccde764c0583f2d99ef03625b7db6da23518db6c82df65921d2a411023
+    size: 860548
+    checksum: sha256:dc56cba4ea8324e48f13e39d4388d06419f742c5fa3c581855254cf1e6648690
     name: iproute
-    evr: 6.2.0-6.el9_4
-    sourcerpm: iproute-6.2.0-6.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/k/kmod-28-9.el9.aarch64.rpm
+    evr: 6.11.0-1.el9
+    sourcerpm: iproute-6.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/k/keyutils-1.6.3-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 131319
-    checksum: sha256:393f67a8d1989408528554460b3e72830eb7d1a531b1f05c6b7d6984d56e5617
+    size: 78563
+    checksum: sha256:98d9e6b3ed8dd32d5c5e48ec6227891dc0dfc9b4f8c7dd08faf825602115e4ce
+    name: keyutils
+    evr: 1.6.3-1.el9
+    sourcerpm: keyutils-1.6.3-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 130824
+    checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
     name: kmod
-    evr: 28-9.el9
-    sourcerpm: kmod-28-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/k/kmod-libs-28-9.el9.aarch64.rpm
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/k/kmod-libs-28-10.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 65329
-    checksum: sha256:85cac74df781d3d9c3ff1e388afe413eb8aa078b6c9580dba2c06c68e90cad26
+    size: 65172
+    checksum: sha256:034496ce5f4ab068b21e4b53a3cf0845fb126b03fcda430b7e2636812092f460
     name: kmod-libs
-    evr: 28-9.el9
-    sourcerpm: kmod-28-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/less-590-4.el9_4.aarch64.rpm
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/less-590-5.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 169466
-    checksum: sha256:a32ed746611b866e6c26d64b9b39366bba5af99f07c808283292231ae6bcb149
+    size: 169771
+    checksum: sha256:07633e451edaf2bfe689d3ee28ddc6e8762dcc7d08a9fbb83246ee4999cf17ba
     name: less
-    evr: 590-4.el9_4
-    sourcerpm: less-590-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libbpf-1.3.0-2.el9.aarch64.rpm
+    evr: 590-5.el9
+    sourcerpm: less-590-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libbpf-1.5.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 177586
-    checksum: sha256:90243203e9c3288b75154127eecc5608b8048251a6e3d11a1e923346cc360b40
+    size: 191251
+    checksum: sha256:05fe053e84ffca806d3f6c4dedebdfb61b8362bdbc0e3508875dec6c2db71d23
     name: libbpf
-    evr: 2:1.3.0-2.el9
-    sourcerpm: libbpf-1.3.0-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
+    evr: 2:1.5.0-1.el9
+    sourcerpm: libbpf-1.5.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 59368
     checksum: sha256:93a2f44044ab11225b1123bc9df4f4d09c0a5f3251818e7d144ca64fd12c0957
     name: libcbor
     evr: 0.7.0-5.el9
     sourcerpm: libcbor-0.7.0-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libcomps-0.1.18-1.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libcomps-0.1.18-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 79615
     checksum: sha256:cbe13dadf0b61de3a258036baab50d70fbecb9bdcd07565b394589f58e2c6da8
     name: libcomps
     evr: 0.1.18-1.el9
     sourcerpm: libcomps-0.1.18-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libdb-5.3.28-53.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libdb-5.3.28-55.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 731377
-    checksum: sha256:7b60c9dcb68b34bf87ada12f9b3a3987ca9d14cb440c06e5bd782cca82e74962
+    size: 727578
+    checksum: sha256:9b20dcbdf347278363c3305a35be0691444e295c43b64181cb67d1b73499f10e
     name: libdb
-    evr: 5.3.28-53.el9
-    sourcerpm: libdb-5.3.28-53.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libeconf-0.4.1-3.el9_2.aarch64.rpm
+    evr: 5.3.28-55.el9
+    sourcerpm: libdb-5.3.28-55.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 29368
-    checksum: sha256:2c34f23375ccf03911786627f4a76add4eba33b10d60869ab4b3ce5c818c2d8b
+    size: 29577
+    checksum: sha256:b6f435b6b79b8a62729f581edead46542dc61fe7276117b2354c324c44ba8309
     name: libeconf
-    evr: 0.4.1-3.el9_2
-    sourcerpm: libeconf-0.4.1-3.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.aarch64.rpm
+    evr: 0.4.1-4.el9
+    sourcerpm: libeconf-0.4.1-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 107505
     checksum: sha256:a56a79e2254db3d351dce58e9960921aec45715b6b7c93eb7a0f453d1e60bae4
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-18.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-21.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 155204
-    checksum: sha256:162c83c3c1aef0f9a102a588c97cad26e6c6adee2086790d409ce91ce93823dc
+    size: 153926
+    checksum: sha256:e39cadb3e0cfd498fa1f37ec76d5f28af35a29b23c4ab163a21d0abc868e156f
     name: libfdisk
-    evr: 2.37.4-18.el9
-    sourcerpm: util-linux-2.37.4-18.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
+    evr: 2.37.4-21.el9
+    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 100573
     checksum: sha256:e56e963635b92f407471c7c5698d602135b135bda4515ecc75ac52dd1d38c7e4
     name: libfido2
     evr: 1.13.0-2.el9
     sourcerpm: libfido2-1.13.0-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libibverbs-48.0-1.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libgomp-11.5.0-5.el9_5.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 408984
-    checksum: sha256:ff8df9c76aedd0bdaf1401cc711208ff85f77b94d92954faca3980e00f0d9a97
+    size: 267717
+    checksum: sha256:417eeb095770944a0c25551771d9ae2ea367b3c979eba9da8a529957f49bafa5
+    name: libgomp
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libibverbs-54.0-1.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 459278
+    checksum: sha256:e64d3c31cf547cee1ad95c144483f71082716f5ee659cdd7f06d0bcde590c3b2
     name: libibverbs
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.aarch64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 30479
     checksum: sha256:b07344f5116a1913e746042748b05f978d284833282d9633e29f3d595ab596e9
     name: libmnl
     evr: 1.0.4-16.el9_4
     sourcerpm: libmnl-1.0.4-16.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 354837
-    checksum: sha256:7f6bd8eaf3817e1c31bb23d935820cce6db3538c22d9443fbce95854177f27f4
+    size: 363241
+    checksum: sha256:91c7bf60c756cd2a457652b95e96e725068898f4ce580b70784fc60a099621b5
     name: libnl3
-    evr: 3.9.0-1.el9
-    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.aarch64.rpm
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 52161
     checksum: sha256:32d8aea6849a815e201cdce925fb3c6de2088cfcb7f6621e93495b605abe2f13
     name: libpipeline
     evr: 1.5.3-4.el9
     sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 38310
     checksum: sha256:9bdfccf6b092e0683aa6984f7c6caa737b30c0b1495e16abb03b5d1a5f8e787a
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 125712
     checksum: sha256:1657d94bbd79f93dc7a79d474316813bde681ce3a7f62f73314ec4d630e39349
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 76024
     checksum: sha256:fc1d5e93483d166ca7f2acb50c04c181db2f3e7b89dba8edc6b1e5f2b0f10619
     name: libseccomp
     evr: 2.5.2-2.el9
     sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libselinux-utils-3.6-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 198305
-    checksum: sha256:8272ab39ab64ab4bde0c5e31387be6e28270a1b1d81a33ba621e6e677b9e974e
-    name: libselinux-utils
-    evr: 3.6-1.el9
-    sourcerpm: libselinux-3.6-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 30505
     checksum: sha256:d352371cbb7d5bd0c53fc699df953c8c1f184b056690b3c4571e57a6634015c5
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 550249
     checksum: sha256:351a22b0e6744bd329b1b0f22d9c3b69a6da970b575e6c76190cc84b0fe77450
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/m/man-db-2.9.3-7.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/m/man-db-2.9.3-7.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 1237575
     checksum: sha256:92784f65ab1e5b2e7060497f23c609251796e07b875bb069599690cec1b4bd37
     name: man-db
     evr: 2.9.3-7.el9
     sourcerpm: man-db-2.9.3-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 418858
     checksum: sha256:5d646286b1f79fa893c17c50605566682a70d924492b769ae2f288ed9dd30947
     name: ncurses
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/n/numactl-libs-2.0.16-3.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/n/numactl-libs-2.0.19-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 31810
-    checksum: sha256:8fc1e4b1fb14c0a6e6e6544e9104139a29e07c4cd5588bd0824d6702bc6aee7d
+    size: 32996
+    checksum: sha256:2e9665b9829363b82e137ad2a5e1bdfeb3fd1a68ae3253dcdb419d7c4478e8bb
     name: numactl-libs
-    evr: 2.0.16-3.el9
-    sourcerpm: numactl-2.0.16-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pciutils-3.7.0-5.el9.aarch64.rpm
+    evr: 2.0.19-1.el9
+    sourcerpm: numactl-2.0.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-8.7p1-45.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 95849
-    checksum: sha256:89dbc095894c4ec9076ad6dd2b5b00445e27521d1a9934cdf48f6405d62b99d3
+    size: 463778
+    checksum: sha256:61e5df0df8802317203a9f4d4a2e928521905fe5a7f527130ab1f1dedfde2ef0
+    name: openssh
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 705047
+    checksum: sha256:c8588d3934dd98ad635e0cafade53b522a9f0984f0d22cfa438b10742f345e22
+    name: openssh-clients
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 1398689
+    checksum: sha256:f914250a9ef52968e27af0f0e2520745df4443dc354367bec54dd06b4a2da60b
+    name: openssl
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/pam-1.5.1-23.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 645611
+    checksum: sha256:9455e74b37d76386da70810917219eae05cf4524733e660ea9492b07050b8f68
+    name: pam
+    evr: 1.5.1-23.el9
+    sourcerpm: pam-1.5.1-23.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/pciutils-3.7.0-7.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 95797
+    checksum: sha256:6442e2a06eedbed95bdf4c72c99a2bace611f88b8de85763a531890495d0736c
     name: pciutils
-    evr: 3.7.0-5.el9
-    sourcerpm: pciutils-3.7.0-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pciutils-libs-3.7.0-5.el9.aarch64.rpm
+    evr: 3.7.0-7.el9
+    sourcerpm: pciutils-3.7.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/pciutils-libs-3.7.0-7.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 41925
-    checksum: sha256:20d254d2efcb133e24a35a4efbab6dcf64650d2bb7422c8265c79d1268e087f6
+    size: 41241
+    checksum: sha256:f7fd6fa012a09505c371b7c572e84e23cb253670a954066b0b77b53ec5975602
     name: pciutils-libs
-    evr: 3.7.0-5.el9
-    sourcerpm: pciutils-3.7.0-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
+    evr: 3.7.0-7.el9
+    sourcerpm: pciutils-3.7.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 45196
     checksum: sha256:aa38a3951a690d721a815ea8f9b01995a85f35a8540d8075205821011d0385e6
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 12398
     checksum: sha256:47f1f744f96a2f3d360bc129837738dcebb1ee5032effc4472a891eea1d6a907
     name: pkgconf-pkg-config
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 251813
-    checksum: sha256:81e7f4a37458072b2f0f86bdb36321ea5e30ef114ffb6a4e0a37fb29fd1c99a6
-    name: policycoreutils
-    evr: 3.6-2.1.el9
-    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 363344
     checksum: sha256:a8c7514beb4c3cafa6341f43bbe285319d863b2893a34d91159dc8e90f615dd2
     name: procps-ng
     evr: 3.3.17-14.el9
     sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/psmisc-23.4-3.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/psmisc-23.4-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 252522
     checksum: sha256:609ffc1ea49d733bf2fabf521851acf20e62cd873c3679f735bc7486b2434359
     name: psmisc
     evr: 23.4-3.el9
     sourcerpm: psmisc-23.4-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-dnf-4.14.0-9.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-3.9.21-2.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 477657
-    checksum: sha256:a4973ead8c13cdf330e93f605e741814ac74c5212d964514e4088ad43fdcd5ff
+    size: 30453
+    checksum: sha256:ed4aea3b8d74577de1bc4cae540b6710c379d5c2e534cf0f7609b6ba23deabbf
+    name: python3
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-dnf-4.14.0-25.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 480011
+    checksum: sha256:85bdaa101978e4cc1ade26a6c3d024e221e21ee035f4274ebb8ecaa7ef0cd706
     name: python3-dnf
-    evr: 4.14.0-9.el9
-    sourcerpm: dnf-4.14.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-gpg-1.15.1-6.el9.aarch64.rpm
+    evr: 4.14.0-25.el9
+    sourcerpm: dnf-4.14.0-25.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-gpg-1.15.1-6.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 288063
     checksum: sha256:2613cde45e991f83f14d39c059746cbc195e296cf16c207d853383eb4ed43dd6
     name: python3-gpg
     evr: 1.15.1-6.el9
     sourcerpm: gpgme-1.15.1-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-hawkey-0.69.0-8.el9_4.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-hawkey-0.69.0-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 99249
-    checksum: sha256:4c73c2c66f47e2ed0972607299f878e11b77bfd146845ba08d3b6b0954589b6f
+    size: 98780
+    checksum: sha256:5ea58180f5ff88896f7bc36cc5ee3806c609e128cb7bbfd048b2c2aedb3ffa9f
     name: python3-hawkey
-    evr: 0.69.0-8.el9_4.1
-    sourcerpm: libdnf-0.69.0-8.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-libcomps-0.1.18-1.el9.aarch64.rpm
+    evr: 0.69.0-13.el9
+    sourcerpm: libdnf-0.69.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-libcomps-0.1.18-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 53332
     checksum: sha256:9dd2bfddff642d37b5a74057921e85a627cbd4cdee4e3d4d4f9a891a907660b3
     name: python3-libcomps
     evr: 0.1.18-1.el9
     sourcerpm: libcomps-0.1.18-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-libdnf-0.69.0-8.el9_4.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-libdnf-0.69.0-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 746826
-    checksum: sha256:3155ab830e3262018c60632476b1c56fb48e91c82ed5b4bbfe859081fd851037
+    size: 745593
+    checksum: sha256:322702bd83a62a1892edeef9629d8272f6739a1f26843a8d3b40a46781ac0fbd
     name: python3-libdnf
-    evr: 0.69.0-8.el9_4.1
-    sourcerpm: libdnf-0.69.0-8.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.2.3-8.el9.noarch.rpm
+    evr: 0.69.0-13.el9
+    sourcerpm: libdnf-0.69.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 1182551
-    checksum: sha256:14411411738a6312e0419c55cba18610d1fc284e1b1b988f578cff5147462fb3
+    size: 8464794
+    checksum: sha256:1710080c9ccb6df1245a2b662b65086be9c13f36340fc81165944b0549c13b8a
+    name: python3-libs
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 1193706
+    checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
     name: python3-pip-wheel
-    evr: 21.2.3-8.el9
-    sourcerpm: python-pip-21.2.3-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-rpm-4.16.1.3-29.el9.aarch64.rpm
+    evr: 21.3.1-1.el9
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-rpm-4.16.1.3-37.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 69657
-    checksum: sha256:97722cf3d797b17cbfdd6520d92cf0f9b0bdff6e497afab1f1719b600f172c53
+    size: 69733
+    checksum: sha256:723ee955da176f1f02095516a31eb8762810aa7c95e16e3863a86c110f9a83f5
     name: python3-rpm
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-12.el9_4.1.noarch.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 480119
-    checksum: sha256:81c47e6a77e1e4e349e13366898ba59d2c7898e844067f3430d8740de2748c61
+    size: 480100
+    checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
     name: python3-setuptools-wheel
-    evr: 53.0.0-12.el9_4.1
-    sourcerpm: python-setuptools-53.0.0-12.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/r/rdma-core-48.0-1.el9.aarch64.rpm
+    evr: 53.0.0-13.el9
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/r/rdma-core-54.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 63527
-    checksum: sha256:717bd89481951bf535e0d7ad7166a755589af257555895493fecd404b302a1ec
+    size: 67451
+    checksum: sha256:679b84c96f2c67592f0200d9d721b3cf9b0d64c4f555fc6eceb0fa829adb7d5c
     name: rdma-core
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/r/rpm-build-libs-4.16.1.3-29.el9.aarch64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/r/rpm-build-libs-4.16.1.3-37.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 89448
-    checksum: sha256:9888a69b10a9b8193702b803296b1bdfdc188a751769e1aae06827c1154454e0
+    size: 89402
+    checksum: sha256:770c48eb80d76bec48045aa3691399a5dc5fc18e490baf419eb13516ce39710e
     name: rpm-build-libs
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/r/rpm-sign-libs-4.16.1.3-29.el9.aarch64.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/r/rpm-sign-libs-4.16.1.3-37.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 21846
-    checksum: sha256:5de8bbc85c804d6294c28046e3c5ed01b518ffbf9e6f6d05dc6bf3a8c05f0927
+    size: 21817
+    checksum: sha256:793fecafd57af811b4728688a2c37acf7d04d15c35da1e731b40b9c0fece3554
     name: rpm-sign-libs
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/s/systemd-252-32.el9_4.7.aarch64.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/r/rsync-3.2.5-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 4160614
-    checksum: sha256:51098e78ba77ea06c086d24a3dac37ce2133cc708f216af9b1d5c5a24f8953f7
+    size: 416293
+    checksum: sha256:99235a7555f6454898ebbcdcf927ebed68e3a60599c9226b9d1d60578d292878
+    name: rsync
+    evr: 3.2.5-3.el9
+    sourcerpm: rsync-3.2.5-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-252-51.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 4178904
+    checksum: sha256:de3f63f5ef5391f65423674b92d29ec2ac3858ac516ced95e7f3e14c35ec9726
     name: systemd
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/s/systemd-pam-252-32.el9_4.7.aarch64.rpm
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-pam-252-51.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 279190
-    checksum: sha256:4e25eeb838ce6d062353160e558bb2d6f420ef10009d35885030e82cd8e335e7
+    size: 284237
+    checksum: sha256:12aa76257995d25bc81ad6c2e2ff0a7acaaf5dd2862b391a0e9d443b0fdbf3a3
     name: systemd-pam
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-32.el9_4.7.noarch.rpm
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 72883
-    checksum: sha256:27dfee433fe47cd843c8e610428f5167b1b12bc03e2bc831bca27dee15aadaf1
+    size: 77716
+    checksum: sha256:3cbe727507a7bc53773cd360372d7be3876f8ddf29b0181158c7f250caa3331c
     name: systemd-rpm-macros
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/t/tar-1.34-6.el9_4.1.aarch64.rpm
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/t/tar-1.34-7.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 900224
-    checksum: sha256:f2b65a333b9de17af1f71e27c7540fa23d85cbe98774a246eb70547d028027da
+    size: 900197
+    checksum: sha256:44552dea889d350403c3074a33d7cb274b3f57553e47db998745df13f931b458
     name: tar
-    evr: 2:1.34-6.el9_4.1
-    sourcerpm: tar-1.34-6.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
+    evr: 2:1.34-7.el9
+    sourcerpm: tar-1.34-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 1137015
     checksum: sha256:a7cf45af14e65509a7f4d33422499372f6fb869bb82695dd4e9004e5c2e4ac1a
     name: tcl
     evr: 1:8.6.10-7.el9
     sourcerpm: tcl-8.6.10-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/t/tpm2-tss-3.2.2-2.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 570083
-    checksum: sha256:cfdd2e932d3b5fbe23fb4e71f42f59eea9ae2944a4c5abb4feb440fcdcdafae9
+    size: 572170
+    checksum: sha256:dc2cc69dcda7cace9f10bf167417ca4f28f002bcb9229b5356b7a3d5e3353b1a
     name: tpm2-tss
-    evr: 3.2.2-2.el9
-    sourcerpm: tpm2-tss-3.2.2-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/u/unzip-6.0-56.el9.aarch64.rpm
+    evr: 3.2.3-1.el9
+    sourcerpm: tpm2-tss-3.2.3-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/u/unzip-6.0-58.el9_5.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 187701
-    checksum: sha256:be8d817c1d35c9a0df6f6f6ef51def3b068646956a9398eb6abf85b14ba97a03
+    size: 186875
+    checksum: sha256:edc9b5c0adcfbe04cbfd4cc6a23d326c82ab816eb1fc521f7e483add8bb2b8cd
     name: unzip
-    evr: 6.0-56.el9
-    sourcerpm: unzip-6.0-56.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/u/util-linux-2.37.4-18.el9.aarch64.rpm
+    evr: 6.0-58.el9_5
+    sourcerpm: unzip-6.0-58.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/u/util-linux-2.37.4-21.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 2394535
-    checksum: sha256:68c822df014bf1fe78985d1672a1cd42ed82c2f4c4ff517e8dbb397907552edd
+    size: 2391248
+    checksum: sha256:82bd3fae04690f35c634e8cd6ad14faacfe3db2bb398f98fb6c8d50df961978c
     name: util-linux
-    evr: 2.37.4-18.el9
-    sourcerpm: util-linux-2.37.4-18.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-18.el9.aarch64.rpm
+    evr: 2.37.4-21.el9
+    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-21.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 477963
-    checksum: sha256:16dfccafa090ff446a374e81e11224e396f44b9c20eba9144cfb48d46a71f3e1
+    size: 476169
+    checksum: sha256:e1d6b36eaaa048d6cb22799d3c463c95d0aadf5dac83fdcf05e9c047eb396406
     name: util-linux-core
-    evr: 2.37.4-18.el9
-    sourcerpm: util-linux-2.37.4-18.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-20.el9_1.noarch.rpm
+    evr: 2.37.4-21.el9
+    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 22428
-    checksum: sha256:6f0dbb5a2c675b932a0eb650c83b68eb485e02808b02bb27373eef30a283f5bc
+    size: 17723
+    checksum: sha256:744aceed764a5a4f5e4f12a70237ff74cb93c375aabffe4dc245e474628775c2
     name: vim-filesystem
-    evr: 2:8.2.2637-20.el9_1
-    sourcerpm: vim-8.2.2637-20.el9_1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.aarch64.rpm
+    evr: 2:8.2.2637-22.el9_6
+    sourcerpm: vim-8.2.2637-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 235798
     checksum: sha256:26ac21be6c1e396c7bcbaa9d4786e3275e996d9d78c01f75bbbc6962e6c9bef7
     name: xz
     evr: 5.2.5-8.el9_0
     sourcerpm: xz-5.2.5-8.el9_0.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/y/yum-4.14.0-9.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/y/yum-4.14.0-25.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 94730
-    checksum: sha256:f2d142cfaa1a2074fd0971181ebcd3832e425a3a58042e86bfa6bcc95a46301f
+    size: 93904
+    checksum: sha256:cf8b191674efee22dc2f01e8932a6edc26f9ec2fdcc1f1cbe303b06d1958d439
     name: yum
-    evr: 4.14.0-9.el9
-    sourcerpm: dnf-4.14.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/codeready-builder/os/Packages/l/libarchive-devel-3.5.3-4.el9.aarch64.rpm
-    repoid: codeready-builder-for-rhel-9-aarch64-rpms
-    size: 138612
-    checksum: sha256:0dffdaf496bd0bb1b320be053b6366f0fcb522e59d27301bd76e26c95925ba78
-    name: libarchive-devel
-    evr: 3.5.3-4.el9
-    sourcerpm: libarchive-3.5.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/c/cpp-11.4.1-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 10793089
-    checksum: sha256:763b38ec9b982b3253bac4a81dcb7be622e5f77a7d2ee5f3e6ba145ad7829ceb
-    name: cpp
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/d/dpdk-23.11-2.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 1662788
-    checksum: sha256:c41f364000d57e65d35e630ef4ee6e4657581e368329f4cea305b16cc56da077
-    name: dpdk
-    evr: 2:23.11-2.el9_4
-    sourcerpm: dpdk-23.11-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/d/dpdk-devel-23.11-2.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 4360540
-    checksum: sha256:e0c344501d06c334899d9537cbda09f794772c3181bee23bf4ac9a0fb6113e75
-    name: dpdk-devel
-    evr: 2:23.11-2.el9_4
-    sourcerpm: dpdk-23.11-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/d/dpdk-tools-23.11-2.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 30044
-    checksum: sha256:7062c45699b3f59265a5fd561c3db9ff3f7102831bc511700368c41284bcbcdc
-    name: dpdk-tools
-    evr: 2:23.11-2.el9_4
-    sourcerpm: dpdk-23.11-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/e/emacs-filesystem-27.2-10.el9_4.2.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 8564
-    checksum: sha256:531d6b7ebe0141d525c89b849c06dce4466de6c44c6811216cf048369d30acfa
-    name: emacs-filesystem
-    evr: 1:27.2-10.el9_4.2
-    sourcerpm: emacs-27.2-10.el9_4.2.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/gcc-11.4.1-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 31258590
-    checksum: sha256:e9f3dcc635528fec74d36fd439c5876bccdce948d58f83345b1973e7379ef507
-    name: gcc
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/git-2.43.5-1.el9_4.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 51741
-    checksum: sha256:db59dce5887da2d91e9320c6bf5c75d49100722cc1e220e457e4844019b67c75
-    name: git
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/git-core-2.43.5-1.el9_4.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 4734183
-    checksum: sha256:32c6a224025a579a2858182097eff2700e3765967ca0214ec01b3a517d6048a3
-    name: git-core
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/git-core-doc-2.43.5-1.el9_4.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 3075181
-    checksum: sha256:7a1fbab9fe6b7e6de67b7d1e1ec10c985396e60001e3a9cf8015f4470716bb94
-    name: git-core-doc
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/glibc-devel-2.34-100.el9_4.10.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 556782
-    checksum: sha256:82b8d8fbee5eee1ba094408697eb7a44f31e453ba884f57f793ca0dd13d31c8f
-    name: glibc-devel
-    evr: 2.34-100.el9_4.10
-    sourcerpm: glibc-2.34-100.el9_4.10.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/glibc-locale-source-2.34-100.el9_4.10.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 4354904
-    checksum: sha256:9e3db3a599257ff448c150565efb9624af28631495119ccd16f66f35efc0fa54
-    name: glibc-locale-source
-    evr: 2.34-100.el9_4.10
-    sourcerpm: glibc-2.34-100.el9_4.10.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-427.68.2.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 4479701
-    checksum: sha256:d414fb958cce83afc16a2080fdca02c2e81b6c659209a6318fdae76e358c530c
-    name: kernel-headers
-    evr: 5.14.0-427.68.2.el9_4
-    sourcerpm: kernel-5.14.0-427.68.2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/l/libasan-11.4.1-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 410341
-    checksum: sha256:907086eb8540a4ae846cd6a81661026e77e988a54c8d6de9c8a499557537b589
-    name: libasan
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/l/libubsan-11.4.1-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 180497
-    checksum: sha256:e651887af299729f3bdb651827f1539470a45e4fd6c554b0f48fd3708ce3eee5
-    name: libubsan
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/p/perl-Git-2.43.5-1.el9_4.1.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 38619
-    checksum: sha256:a69b55fef7675e204d88435984c4443d34b7964dfc8e06d1bbce355b8dcf5efa
-    name: perl-Git
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.18-3.el9_4.7.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
-    size: 10336
-    checksum: sha256:0422c5e81b216b5bbcffde24ae94e653cf95df5c4bc4f6507b77e12bfebe5b3b
-    name: python-unversioned-command
-    evr: 3.9.18-3.el9_4.7
-    sourcerpm: python3.9-3.9.18-3.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/e/expat-2.5.0-2.el9_4.2.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 116170
-    checksum: sha256:e6116fa3b64aabf1aea9a4c28dfe1519badaace540bb77a932341378f4d53677
-    name: expat
-    evr: 2.5.0-2.el9_4.2
-    sourcerpm: expat-2.5.0-2.el9_4.2.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/l/libgomp-11.4.1-4.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 264568
-    checksum: sha256:d2018bfb5f0efe37e2ac236735c8a7aa845802e631c9f4de7535a53e6140b8ee
-    name: libgomp
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/o/openssh-8.7p1-38.el9_4.5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 463505
-    checksum: sha256:2d90c96a3b297af8a0a3c89b0836c0b12317d6225ad20bfc8f892fcea4ef0ae5
-    name: openssh
-    evr: 8.7p1-38.el9_4.5
-    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-38.el9_4.5.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 705635
-    checksum: sha256:88c3b641ec06dc581063dbd5934342db8a4996287dfcb51a8ef5f5665df8e23d
-    name: openssh-clients
-    evr: 8.7p1-38.el9_4.5
-    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/o/openssl-3.0.7-29.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 1244228
-    checksum: sha256:aa2685dd4c7134d38eb069f8bc2e1ec130d3422dd050d26c00949c5a917cc3c4
-    name: openssl
-    evr: 1:3.0.7-29.el9_4
-    sourcerpm: openssl-3.0.7-29.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/p/pam-1.5.1-23.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 646222
-    checksum: sha256:847c541334b8570cd9c5a39666c899e6ab96a708ad2f5a4ba8cd89429242b5fd
-    name: pam
-    evr: 1.5.1-23.el9_4
-    sourcerpm: pam-1.5.1-23.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-3.9.18-3.el9_4.7.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 30242
-    checksum: sha256:2c6e6e95d7104a3fbd93f2ec2f74a63b40834594bf413c2c75d6150bdf0eb6f7
-    name: python3
-    evr: 3.9.18-3.el9_4.7
-    sourcerpm: python3.9-3.9.18-3.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/p/python3-libs-3.9.18-3.el9_4.7.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 8206233
-    checksum: sha256:dd121e7e5d8483dbff2cb4647193c1b0565c4a9c47e9565b2c3c673860bead19
-    name: python3-libs
-    evr: 3.9.18-3.el9_4.7
-    sourcerpm: python3.9-3.9.18-3.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/r/rsync-3.2.3-19.el9_4.1.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
-    size: 404393
-    checksum: sha256:86802e6f9fa68bcef00aabe04bcf601201292cf9bf79370992d11dbb853ddc1c
-    name: rsync
-    evr: 3.2.3-19.el9_4.1
-    sourcerpm: rsync-3.2.3-19.el9_4.1.src.rpm
+    evr: 4.14.0-25.el9
+    sourcerpm: dnf-4.14.0-25.el9.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/b/bsdtar-3.5.3-4.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/b/bsdtar-3.5.3-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 67365
     checksum: sha256:df015c061e8a5e4df56be71d1730f13a5dd17f937e232276af1861c2ebeace39
     name: bsdtar
     evr: 3.5.3-4.el9
     sourcerpm: libarchive-3.5.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/e/expect-5.45.4-16.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 11229073
+    checksum: sha256:b5567c690d46d4f5a2cb13be6a4f962dbe8cc7e821b9d3baa09a4f10c59014d9
+    name: cpp
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/d/dpdk-24.11.1-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 4170444
+    checksum: sha256:a782f566e19cd4f4a5451c977f55c31f4f4aff9e715edda233e3afec9161d97c
+    name: dpdk
+    evr: 2:24.11.1-2.el9
+    sourcerpm: dpdk-24.11.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/d/dpdk-devel-24.11.1-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 4564494
+    checksum: sha256:65d94754df73ddb95f55960d636e22364bb285dc0143ae9f8ad6e1c0e85edcff
+    name: dpdk-devel
+    evr: 2:24.11.1-2.el9
+    sourcerpm: dpdk-24.11.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/d/dpdk-tools-24.11.1-2.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 35443
+    checksum: sha256:5ee6e6e9fef933ff92ed32d581cc451d400eccff69d62a36aa0d26543031e115
+    name: dpdk-tools
+    evr: 2:24.11.1-2.el9
+    sourcerpm: dpdk-24.11.1-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-13.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 9758
+    checksum: sha256:624b6683efb3e254eb8f44a927772ec251a841803b7f693f9c6ad0651e694557
+    name: emacs-filesystem
+    evr: 1:27.2-13.el9_6
+    sourcerpm: emacs-27.2-13.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/e/expect-5.45.4-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 260241
     checksum: sha256:acc8ca3382fb714eb09ac4d22e832094d2c5700a4dc639ffa75c20cb3d3479da
     name: expect
     evr: 5.45.4-16.el9
     sourcerpm: expect-5.45.4-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/i/infiniband-diags-48.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/gcc-11.5.0-5.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 343925
-    checksum: sha256:0384f5ecf43418fea94692b3123ad737eae24e87467608247db654fdcb605f49
+    size: 34006000
+    checksum: sha256:03c99bc1021dbe54dd93120ed6b5249bbb02dbd5da9e0dc5d8c4a21d674fb1fd
+    name: gcc
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/git-2.47.1-2.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 55489
+    checksum: sha256:35c844a31e6877ad10dcd4c695f3f159ab88dc6978bc98b45b8ee47e94b5536b
+    name: git
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/git-core-2.47.1-2.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 4947862
+    checksum: sha256:ae898605cf906ea73181921224143895e20a6eca5df56e8b092bc78e634cb09f
+    name: git-core
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/git-core-doc-2.47.1-2.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 3194257
+    checksum: sha256:172dd65142fcd6548658a47e46d06a9a80251ab7a2cd6da6a0a99bb92e83cb56
+    name: git-core-doc
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.14.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 35566
+    checksum: sha256:1565ca914cb58037fc9f50af64be3a43d5ae854b5d30f01882eb06d57c44d52c
+    name: glibc-devel
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/glibc-headers-2.34-168.el9_6.14.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 554474
+    checksum: sha256:10579e7e1a0140841209c023fdb9034aae1b3723ab5807f6e6c61e8dd2dbffa7
+    name: glibc-headers
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/g/glibc-locale-source-2.34-168.el9_6.14.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 4358158
+    checksum: sha256:74a67eca11e4edfb6021fe42db1bdb97cbc983f61e8037b4e6cb82ad00c0904f
+    name: glibc-locale-source
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/i/infiniband-diags-54.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 350069
+    checksum: sha256:f8f143480519d6412d36192f771a83779c75e605296d52954ae62e18b70f1711
     name: infiniband-diags
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.17.1.el9_6.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 3680573
+    checksum: sha256:03dcb738b60220f6576812e7d4c7afdeb732b76d5d48b04c0603cce638b4ee9e
+    name: kernel-headers
+    evr: 5.14.0-570.17.1.el9_6
+    sourcerpm: kernel-5.14.0-570.17.1.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libarchive-devel-3.5.3-4.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 138653
+    checksum: sha256:9bb8330d80109adcd2f6049cc376bdce41d330982ccd07c19f0e97641c21edd7
+    name: libarchive-devel
+    evr: 3.5.3-4.el9
+    sourcerpm: libarchive-3.5.3-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 66075
     checksum: sha256:b97b4e98c3c6f41dcfc2ceb4ffa1aba7a338b7cfd9e6c4f63e3160dd3cc033d3
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 93189
     checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
     name: libxcrypt-compat
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 33101
     checksum: sha256:c1d171391a7d2e043a6953efd3df3e01edc9b4c6cdb54517e1608d204a5fce18
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 21821
     checksum: sha256:52cda881960f48be35a47ba1c54f242efac1ab0d1fd74b0e2bcb48a1723907c8
     name: perl-AutoLoader
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-B-1.80-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-B-1.80-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 188182
     checksum: sha256:1d9743f0a5ba875908984dbe875025aa51bc62fc9d1bec3fbef12f6688c1d771
     name: perl-B
     evr: 1.80-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 22914
     checksum: sha256:45347749c36c4750c9083d4784700fb85c3a4c277c3bf69873a1c6ae97ee6c4b
     name: perl-Class-Struct
     evr: 0.66-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 59910
     checksum: sha256:6cd912e640cbc8785e33dae9cf07561509491a0ec76a81c01d6b7a77ad08668d
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 40274
     checksum: sha256:2a6b21a144ae1d060e51ee2b6328c5dd1a646f429da160f386c2eb420b1220b4
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 26423
     checksum: sha256:f238e85f5fe854109793f966e7e36f14165979aee78fc2de39037b9f69ca3178
     name: perl-DynaLoader
     evr: 1.47-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1802386
     checksum: sha256:d05248697e48928be004ed4c683b04966aa452ae1e2bd81f650c6de108b46956
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15331
     checksum: sha256:891006d2a5ec8528b1e7fe181a3e1617733b1050250b381f29261b70e83865ed
     name: perl-Errno
     evr: 1.30-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Error-0.17029-7.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 47552
     checksum: sha256:17cecf9160050d4709f4817eceba32c637e10d8bc87487a754e8f1764b1e8b6a
     name: perl-Error
     evr: 1:0.17029-7.el9
     sourcerpm: perl-Error-0.17029-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 22098
     checksum: sha256:726645728dabb2f1badb1c4a6170c5db29118a536cdfa482c882aaef6ed97fb4
     name: perl-Fcntl
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17916
     checksum: sha256:746f919f1aebc91a28f00e20eda7b41991db9e50abf2fa22cd7f8168a8f9898a
     name: perl-File-Basename
     evr: 2.85-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 26277
     checksum: sha256:e388937b023c024de285a5b50fe3f44722c18207d7d854aff302f4ad3c8742f4
     name: perl-File-Find
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 17853
     checksum: sha256:355aba30d043f829e4e7e70466564ba85f65f7a2416aba0ceddfc9e59288aab4
     name: perl-File-stat
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15921
     checksum: sha256:480ac4c1de2c1e1f94ed8895793b93d96bd50dc95e6e4fa9c39a82a24998f717
     name: perl-FileHandle
     evr: 2.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 16222
     checksum: sha256:c9c6209474ec44ca5b070ffb147589359c551757f95b358a8f35d2627c4950cf
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Git-2.47.1-2.el9_6.noarch.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 40089
+    checksum: sha256:3bb2b9b3f197bb548455a5ed7304ef25510f4ae6f4ee92dd4db74946a869442e
+    name: perl-Git
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-IO-1.43-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IO-1.43-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94663
     checksum: sha256:dc85c28902667c1bd3c6f19b6a08bdda5e1d25b11e832b269e15fde94e6ab52d
     name: perl-IO
     evr: 1.43-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 228493
-    checksum: sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f
+    size: 226003
+    checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
-    evr: 2.073-1.el9
-    sourcerpm: perl-IO-Socket-SSL-2.073-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
+    evr: 2.073-2.el9
+    sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 24124
     checksum: sha256:422c83bcdd2f84d9751fe4ea289e6bc8bfbc41e6540d6482671317fbc2ff1a17
     name: perl-IPC-Open3
     evr: 1.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 35058
     checksum: sha256:3ae8affe13cc15cfaee1c6dd078ada14891dde5dca263927a9b5ed87f241d2c0
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 23899
     checksum: sha256:fbd179e177943079b17db7c887b77dcca46b009ae41d85da5c16e1f33d20a1c9
     name: perl-NDBM_File
     evr: 1.15-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.92-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 401501
-    checksum: sha256:eb0402981b2fce935550fef841f4c6eb24928456370e8b7b689ca073db3d2708
+    size: 428188
+    checksum: sha256:d8ed17b9700c4acee11a339c9e0814862ad5b20e072c1414021dcb050c7da90b
     name: perl-Net-SSLeay
-    evr: 1.92-2.el9
-    sourcerpm: perl-Net-SSLeay-1.92-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.x86_64.rpm
+    evr: 1.94-1.el9
+    sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 100044
     checksum: sha256:70b078b5b692c8d8b26600ae4868b50d613289a89c50b702109bce542d2c8888
     name: perl-POSIX
     evr: 1.94-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 94564
     checksum: sha256:0647785b169c4bbdc65adf06d28981ce7fd1c9f93aecaa4e53a4515a21ebbf81
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-461.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 78835
-    checksum: sha256:67c76fc091d9e621f225d492ad80e24ec96e6b96cd5d01f980814e9b7882429b
+    size: 77262
+    checksum: sha256:7ce874bde7d9ad15abf70a3b7edbab77548eb2eb8b529c1e48b2426ee7f948f9
     name: perl-Scalar-List-Utils
-    evr: 4:1.56-461.el9
-    sourcerpm: perl-Scalar-List-Utils-1.56-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
+    evr: 4:1.56-462.el9
+    sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 12017
     checksum: sha256:c4f02fdf5b501ab67b4824fc4473ba420f482254ad82e90b546d9b10a5464820
     name: perl-SelectSaver
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 59776
     checksum: sha256:762751146305f9aea53b74a21495a610e7bdde956fa3246565d265b1128b56a8
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 100335
     checksum: sha256:0097fdb40a1f83e56d5bf91160c07151b7cdd64f829fc0e328cdf3b43c2b4fa6
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 14535
     checksum: sha256:2364cd3b0a19572b16a1379c228046a405851bcd0676860a6aeb9bcb3869498f
     name: perl-Symbol
     evr: 1.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 41023
     checksum: sha256:5ff266e740a93344e1ce2913f4bec0f38cfdf721841e6762d85ac21d716ee9f8
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 16674
     checksum: sha256:dab1d27f285d579c9783e80817f98a2835e7bf06842d704a7f85cfdb7ab4b0a3
     name: perl-base
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 14343
     checksum: sha256:714022b8937ed9c6d4638b99aef0a8426b782e7948019b50b06d9cd2e32e454a
     name: perl-if
     evr: 0.60.800-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 74840
     checksum: sha256:359a94a09f0082a637c5bc2aa4ddac23dd79e929daa38dfed85d0e1afff31fba
     name: perl-interpreter
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-lib-0.65-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-lib-0.65-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15318
     checksum: sha256:89bf58fb4d09ec404ea98063d4a7099ff00b59e9a9e0bb04067f48e3fb581083
     name: perl-lib
     evr: 0.65-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 2303445
     checksum: sha256:d20aebf4d96f4ad0e7dc97b63bbe41baa6f927a34eac9068a22f1d62e71611dc
     name: perl-libs
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-mro-1.23-481.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-mro-1.23-481.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 30125
     checksum: sha256:3cf76960b8c866deebf333a9dfd64a7dd9f4689cb82e37d0c0ddab2c031b3651
     name: perl-mro
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 46643
     checksum: sha256:813598b9d9a3ada4975144cf0dd0f25906589a92c7708556dcbf464501d72848
     name: perl-overload
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 13658
     checksum: sha256:feca093162af099f769448e95170a357f2d2bd66da36299d1a999782d57da51d
     name: perl-overloading
     evr: 0.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 11986
     checksum: sha256:df6327eb3774c2254fc45c630cedf3b32b3bdd7f146bf25ffe0342f9904dac43
     name: perl-subs
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 13347
     checksum: sha256:c54caddd2a5adaf84088833a9eb126e772b6db090800c3293b819f432ddd6b6c
     name: perl-vars
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/r/rdma-core-devel-48.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 481532
-    checksum: sha256:966deb6330c7b20b39b5e61f2ef624cac15e96a01d2fc3ca23b269c17e104187
+    size: 10730
+    checksum: sha256:d835fd578f8ebf17c5914a4d8695ca78e68676880b690dd2a322b541a2897a71
+    name: python-unversioned-command
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/r/rdma-core-devel-54.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 492466
+    checksum: sha256:fac8c9225390ee8e212e887c26f461ea412ddf1c50b8a06b81c737cd4092e484
     name: rdma-core-devel
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-29.el9.x86_64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-37.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 17936
-    checksum: sha256:c449caccd8ce0783e9810d69073711bef50736e79782e3389fa467cbf4c40003
+    size: 18084
+    checksum: sha256:bad0137ad0f9dca0eb001feacf881a0e1613a47a69f018217584eb05e159b106
     name: rpm-plugin-systemd-inhibit
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.x86_64.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/s/scl-utils-2.0.3-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 42223
     checksum: sha256:164d245bec95c7dcbba881fd88ee567bc6d5859329c91ae05a6ad5429700bdbc
     name: scl-utils
     evr: 1:2.0.3-4.el9
     sourcerpm: scl-utils-2.0.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/a/acl-2.3.1-4.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/a/acl-2.3.1-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 77226
     checksum: sha256:150d7232faa90f84a09268f8998ee32670eef59cba98612aeb996ab75c4dfcc4
     name: acl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/b/binutils-2.35.2-43.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/a/attr-2.5.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4814336
-    checksum: sha256:699736ac7d7c7923698dc5e441bdbf6d70f35eeba7ae43d6606ce5dbbf1ec2fb
+    size: 66700
+    checksum: sha256:49f7baeb53e07a4b9b5739e36932f17f014abb765b3fa6c0c0f8af6a8ebf4d9b
+    name: attr
+    evr: 2.5.1-3.el9
+    sourcerpm: attr-2.5.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 4818636
+    checksum: sha256:4eb918b63dee7daf32117df2e3fcb02ad4ba3d96cb25677cf55315deceb7e22a
     name: binutils
-    evr: 2.35.2-43.el9
-    sourcerpm: binutils-2.35.2-43.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-43.el9.x86_64.rpm
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 754052
-    checksum: sha256:943aaa9fcd7455f453d9cb7b2b54b2fdd5d312ee7f88f2f586db666c89260936
+    size: 753176
+    checksum: sha256:339d9bb2dc0e41c4756f1a4f82e82f6654818b72de74f1f0377c76277617352b
     name: binutils-gold
-    evr: 2.35.2-43.el9
-    sourcerpm: binutils-2.35.2-43.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.x86_64.rpm
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 100903
     checksum: sha256:8551b711718596fbfef6622bbf32f785864959af9d06a76da2545ec9f3a126e7
     name: cracklib
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 3821230
     checksum: sha256:ab4356c86bdc996dc9e55703a7ae936e3e46aec6ebf6d6f008e126ff06e83df2
     name: cracklib-dicts
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 8073
     checksum: sha256:96b1daa4de0a635ab760a8431fb005022bb7cb48d2d1d3ec9a8adb1798c0e10e
     name: dbus
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 179634
     checksum: sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb
     name: dbus-broker
     evr: 28-7.el9
     sourcerpm: dbus-broker-28-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 18551
     checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
     name: dbus-common
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/d/dbus-libs-1.12.20-8.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-libs-1.12.20-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 157201
     checksum: sha256:10e1bc01835d6b2185782f7202abb494af81158ec35755ddf3eb98c022f07e08
     name: dbus-libs
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dnf-4.14.0-25.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 411559
-    checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
-    name: diffutils
-    evr: 3.7-12.el9
-    sourcerpm: diffutils-3.7-12.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/d/dnf-4.14.0-9.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 497541
-    checksum: sha256:600d1feac9337bd6d9a65a09f892b4a42651b5bea03da908ab2db63eab315cb1
+    size: 494210
+    checksum: sha256:b13e385796f68e45acf995bf9faa38bbf23f87b56135245244b711b89c58b485
     name: dnf
-    evr: 4.14.0-9.el9
-    sourcerpm: dnf-4.14.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.190-2.el9.x86_64.rpm
+    evr: 4.14.0-25.el9
+    sourcerpm: dnf-4.14.0-25.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.192-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 39619
-    checksum: sha256:8318e4801d9a4e5cb9c0b647b8b3c1d969627d8f8ced0d5220bdddf668583e63
+    size: 47282
+    checksum: sha256:e5b1a7a9e1467bfe00913e9b22ba5665852f8c61900205a32d3043ace9e1c7c2
     name: elfutils-debuginfod-client
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.190-2.el9.noarch.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.192-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 12538
-    checksum: sha256:26aaebd8f1b36f55622d5376e79cdee9da0a69ca45dc6747a8828db4b0c1d24c
+    size: 9839
+    checksum: sha256:fb2fe6a8f7552aecda6c998adddb0f88264252b6f717a306adfd0c24b0e33e79
     name: elfutils-default-yama-scope
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/e/elfutils-libelf-0.190-2.el9.x86_64.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/elfutils-libelf-0.192-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 200209
-    checksum: sha256:319c1247ac3a14d93c9e5086d7f59bed63259ea62c46b5317c372995c0f45073
+    size: 212505
+    checksum: sha256:20ef8ae38ec86e43d0adc5b8473bb8feeb880467dfda93f37f0d362ba06a79bc
     name: elfutils-libelf
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/e/elfutils-libs-0.190-2.el9.x86_64.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/elfutils-libs-0.192-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 264174
-    checksum: sha256:2920ff7f78e81d1fbed58ef6512ca1a5da6069377bbb460992663a97c456ac52
+    size: 270058
+    checksum: sha256:a72237e0bffd7ae464d4c0eb7707947a611dc96a667409c7c4a0e73e75cc4ebc
     name: elfutils-libs
-    evr: 0.190-2.el9
-    sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/e/environment-modules-5.3.0-1.el9.x86_64.rpm
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/environment-modules-5.3.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 605644
     checksum: sha256:0bf2c48686d2c9f4d0f4d2cbe80a64f7d3c26559dd3cf6ca798a6615407a58ae
     name: environment-modules
     evr: 5.3.0-1.el9
     sourcerpm: environment-modules-5.3.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/f/findutils-4.8.0-6.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 563200
-    checksum: sha256:16f7db6388e16f62a21f67752f678f295c034c0f90e4c4acea08d27f61da2acf
+    size: 121835
+    checksum: sha256:63522da84934e944305c9e206894031988ab9e561bba2e6c131d76093d1a0211
+    name: expat
+    evr: 2.5.0-5.el9_6
+    sourcerpm: expat-2.5.0-5.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 563531
+    checksum: sha256:a6328afea0a11647b7fb5c48436f0af6c795407bac0650676d3196dd47070de6
     name: findutils
-    evr: 1:4.8.0-6.el9
-    sourcerpm: findutils-4.8.0-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/gettext-0.21-8.el9.x86_64.rpm
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gettext-0.21-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1193150
     checksum: sha256:febf6aec8699ca352aba5a7a249ed0cb011b68c5bab17f6178f09b1035974dde
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 313328
     checksum: sha256:b319325e941e03e3e7381161889ab39473398194786a52fc1653d025211b6e1a
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1133828
     checksum: sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 171206
     checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/h/hwdata-0.348-9.13.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/h/hwdata-0.348-9.18.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1674692
-    checksum: sha256:c6dd3fc36960df2631bb2cc55d5a9fc431d882ba91336f5f3aef17c15c12b8a7
+    size: 1724460
+    checksum: sha256:3f50d2d645126aab5407531cdfa813544c85c44d312bc19dcc3378460b9eb03d
     name: hwdata
-    evr: 0.348-9.13.el9
-    sourcerpm: hwdata-0.348-9.13.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/i/ima-evm-utils-1.4-4.el9.x86_64.rpm
+    evr: 0.348-9.18.el9
+    sourcerpm: hwdata-0.348-9.18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/ima-evm-utils-1.5-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 68949
-    checksum: sha256:23bad0b0fa4770f108c763810ad4dcd7663c058da4da0aca868f7fe56a2b7544
+    size: 75273
+    checksum: sha256:656c8fa4da9792b3f8dd4515ad4dbb2a0f81f08125371bedc1c1ae55182372d5
     name: ima-evm-utils
-    evr: 1.4-4.el9
-    sourcerpm: ima-evm-utils-1.4-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/i/iproute-6.2.0-6.el9_4.x86_64.rpm
+    evr: 1.5-3.el9
+    sourcerpm: ima-evm-utils-1.5-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iproute-6.11.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 839029
-    checksum: sha256:db38e032a90ccf525599418f595799a0d0d96180984960fda08c8cb99516621a
+    size: 855648
+    checksum: sha256:8fdbd5d311c7002f6553c31406f642ed136e94008b49376d581286646648d11d
     name: iproute
-    evr: 6.2.0-6.el9_4
-    sourcerpm: iproute-6.2.0-6.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/k/kmod-28-9.el9.x86_64.rpm
+    evr: 6.11.0-1.el9
+    sourcerpm: iproute-6.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/keyutils-1.6.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 133058
-    checksum: sha256:6dc2f7567e88d90c149fa8b00e0a541727f8cc13b92cdd02a1ea846c39997be9
+    size: 79682
+    checksum: sha256:756fb606dfbf6c6f92fcd3316ba902b5e09232102cb6371d9bccd983b8d4bbdf
+    name: keyutils
+    evr: 1.6.3-1.el9
+    sourcerpm: keyutils-1.6.3-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 132888
+    checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
     name: kmod
-    evr: 28-9.el9
-    sourcerpm: kmod-28-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/k/kmod-libs-28-9.el9.x86_64.rpm
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-libs-28-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 66809
-    checksum: sha256:836ab8f42bce6a937c8254b6a362a4baf8038ae5755f9a3e29a4f8e4f76f8ca4
+    size: 66607
+    checksum: sha256:9ae0b89812908ee50ec654ba35f74dc478057e8981afd4a5cc8d2befd987b342
     name: kmod-libs
-    evr: 28-9.el9
-    sourcerpm: kmod-28-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/less-590-4.el9_4.x86_64.rpm
+    evr: 28-10.el9
+    sourcerpm: kmod-28-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/less-590-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 170493
-    checksum: sha256:d2d0eef0c702b1e1f26b208ce62033c34f9e7c4776e1a7c83edd13b642cb0c6c
+    size: 170758
+    checksum: sha256:a726061c966a134a5e5b42b60e4162ee85a2cef8843b6fd28e08264ceebb54f4
     name: less
-    evr: 590-4.el9_4
-    sourcerpm: less-590-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libbpf-1.3.0-2.el9.x86_64.rpm
+    evr: 590-5.el9
+    sourcerpm: less-590-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libbpf-1.5.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 178590
-    checksum: sha256:df2208fcac1f3abcd5075d98d113aa0d439981185da1256a0c291073a84d5d16
+    size: 191098
+    checksum: sha256:488a913a5f10debb4fb27756f59da75c61c6fefac403ea62d50b8071625d5cf3
     name: libbpf
-    evr: 2:1.3.0-2.el9
-    sourcerpm: libbpf-1.3.0-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
+    evr: 2:1.5.0-1.el9
+    sourcerpm: libbpf-1.5.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 60575
     checksum: sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526
     name: libcbor
     evr: 0.7.0-5.el9
     sourcerpm: libcbor-0.7.0-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libcomps-0.1.18-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libcomps-0.1.18-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 81851
     checksum: sha256:89c2c46e83f100481ecc279ee886ab0f38a4b4668adff7d779089037f4b19d4f
     name: libcomps
     evr: 0.1.18-1.el9
     sourcerpm: libcomps-0.1.18-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libdb-5.3.28-53.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libdb-5.3.28-55.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 757841
-    checksum: sha256:af6155b09837d119ad1ec4ac48234eec92724c31ccbafa3f330ddc5ae4699627
+    size: 754739
+    checksum: sha256:b019fc2c6ec5d05c7225a189c0e751be4c1c572b82991022809cc8c1f4fa0a89
     name: libdb
-    evr: 5.3.28-53.el9
-    sourcerpm: libdb-5.3.28-53.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libeconf-0.4.1-3.el9_2.x86_64.rpm
+    evr: 5.3.28-55.el9
+    sourcerpm: libdb-5.3.28-55.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 30301
-    checksum: sha256:d2ff8b9c4b0d518331bc7a58af82a5d50cb685a49fc8b26b56d804da74d741d6
+    size: 30371
+    checksum: sha256:f7998382ca1be7836f6af05d42dc03f88799abcb10aa7a761e16f74058598012
     name: libeconf
-    evr: 0.4.1-3.el9_2
-    sourcerpm: libeconf-0.4.1-3.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
+    evr: 0.4.1-4.el9
+    sourcerpm: libeconf-0.4.1-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 109330
     checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-18.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-21.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 160482
-    checksum: sha256:b5790aec9d1dbf0d7098dec8df538b1af0ad727b57924ab23a2f59db29c59f1c
+    size: 159417
+    checksum: sha256:81c7676b72b85d8b5822888c510952ec0996b3d89bf8cddaf76dba31bc72a4a1
     name: libfdisk
-    evr: 2.37.4-18.el9
-    sourcerpm: util-linux-2.37.4-18.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
+    evr: 2.37.4-21.el9
+    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 102746
     checksum: sha256:6da940c0528f3e4453db84cb85b402c8f4293a197b1921158df9651edb4845e0
     name: libfido2
     evr: 1.13.0-2.el9
     sourcerpm: libfido2-1.13.0-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libibumad-48.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libgomp-11.5.0-5.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 28334
-    checksum: sha256:d02ee598f11eb06b811fcd45d740a3849eb05ee0b739c90335db7dbcdd4a4072
+    size: 269396
+    checksum: sha256:da7af36960df4b59178f4d7c42353d48c53fbe231e7e62d734a4319748f897a9
+    name: libgomp
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libibumad-54.0-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 28618
+    checksum: sha256:a174dec96834ebf4cb5072328649f1e833d7df03efa149792a4cd71d59b15985
     name: libibumad
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libibverbs-48.0-1.el9.x86_64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libibverbs-54.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 414261
-    checksum: sha256:db134149c95a0c9f78fbf6f66918694b2f6a0713b02f19e422a312dea36b07d6
+    size: 466434
+    checksum: sha256:fc593dc18f73c296df4fa808341cb2dbee7e5082fb872b79e7984c3b24279d3b
     name: libibverbs
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.x86_64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 30949
     checksum: sha256:badfd4eb5b7cd3622da84168674002ec718ef810ce615a1113d3e19e265b777e
     name: libmnl
     evr: 1.0.4-16.el9_4
     sourcerpm: libmnl-1.0.4-16.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libnl3-3.9.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 367914
-    checksum: sha256:f436a96ba3433f501a7015bec2fa35ac05b52b776f0256b9c8cb3e6268086817
+    size: 376137
+    checksum: sha256:89728a253a5bf1c8e01c40573f1283d40188e003bdbd4ac565f8b0f05bced55c
     name: libnl3
-    evr: 3.9.0-1.el9
-    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpipeline-1.5.3-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 52912
     checksum: sha256:c972030a8fbaa2d981f0e5fdfc42d6d5173dd047c94d86ab7732e3e53fc4e97a
     name: libpipeline
     evr: 1.5.3-4.el9
     sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38387
     checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 126104
     checksum: sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/librdmacm-48.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/librdmacm-54.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 75286
-    checksum: sha256:eaf547b63900a621f43d2d78ec2fcb2bbee57895b890c7b31e573534bed6c085
+    size: 75775
+    checksum: sha256:334a6ff9a86cfed3af1dc2b08b840e74c9cd84b35a8d7bfd15a0db51ca8a0d30
     name: librdmacm
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 76200
     checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
     name: libseccomp
     evr: 2.5.2-2.el9
     sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 198772
-    checksum: sha256:479229e7c3d8cb005dafd637b2973fbee0bb507cfed8e72f7076318513200abd
-    name: libselinux-utils
-    evr: 3.6-1.el9
-    sourcerpm: libselinux-3.6-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 30354
     checksum: sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 553896
     checksum: sha256:561f0c2251e9217c81a6c88de4d2d9231a039aaab37e8a0d2559d36ce9fa85fd
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/m/man-db-2.9.3-7.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/m/man-db-2.9.3-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1245006
     checksum: sha256:1eb7770a27102f59012f704e90aa04b130ab4f46fec983a7441ec9e8810f2da4
     name: man-db
     evr: 2.9.3-7.el9
     sourcerpm: man-db-2.9.3-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 420158
     checksum: sha256:1b5e5805334bc78c977d7acf02256021a9216e26348a5383cf86dfb0b0c91101
     name: ncurses
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/n/numactl-libs-2.0.16-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/n/numactl-libs-2.0.19-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 31909
-    checksum: sha256:3f9b887fd3ba01ab67daf28dc11c0f4c7c296beac0535fb12d0577f8eeb766af
+    size: 33709
+    checksum: sha256:ce2f00b2527e29f6b389e5899750e2b6eb1e5ce484ddfdcd6f01fa311efe7860
     name: numactl-libs
-    evr: 2.0.16-3.el9
-    sourcerpm: numactl-2.0.16-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/pciutils-3.7.0-5.el9.x86_64.rpm
+    evr: 2.0.19-1.el9
+    sourcerpm: numactl-2.0.19-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssh-8.7p1-45.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 98752
-    checksum: sha256:aaa17904b12fe5e7df830fb9c512d971f29221dec19a3e421307b41526696f5e
+    size: 474534
+    checksum: sha256:d43f19d3e736943bdadbda47db016e9da81ce1900f50ecfe470f7a8bc9bce243
+    name: openssh
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 735750
+    checksum: sha256:309d1c9c176bf35b494c8b31a0f3eeceddd0b27be1dfc9defbe9838b9d5a707c
+    name: openssh-clients
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1420999
+    checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
+    name: openssl
+    evr: 1:3.2.2-6.el9_5.1
+    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pam-1.5.1-23.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 647096
+    checksum: sha256:5f261b23e11d27a49e5ddcb83ee93f37834a8160c82a0b82dbe6bf07acdfd96b
+    name: pam
+    evr: 1.5.1-23.el9
+    sourcerpm: pam-1.5.1-23.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pciutils-3.7.0-7.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 98775
+    checksum: sha256:f9790ff09822692f432aa59b8e6e69620ec118fa86d99d7b15ef2f0a6569b442
     name: pciutils
-    evr: 3.7.0-5.el9
-    sourcerpm: pciutils-3.7.0-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/pciutils-libs-3.7.0-5.el9.x86_64.rpm
+    evr: 3.7.0-7.el9
+    sourcerpm: pciutils-3.7.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pciutils-libs-3.7.0-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 44460
-    checksum: sha256:722e3c6fb3dff112298025a33c36da22a5283ce05003aee216ba6bfe740df6b9
+    size: 43562
+    checksum: sha256:468f1102d03ebda5ff883c34fc6a76a6b72faf9f230fbcec61432631943846b9
     name: pciutils-libs
-    evr: 3.7.0-5.el9
-    sourcerpm: pciutils-3.7.0-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+    evr: 3.7.0-7.el9
+    sourcerpm: pciutils-3.7.0-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 45675
     checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 12438
     checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
     name: pkgconf-pkg-config
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 251967
-    checksum: sha256:8dcd39960d3103f7a4ad2b9f7a0e15469ebf4da98f6c215cddfffdb830dc12b5
-    name: policycoreutils
-    evr: 3.6-2.1.el9
-    sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 361526
     checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
     name: procps-ng
     evr: 3.3.17-14.el9
     sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/psmisc-23.4-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/psmisc-23.4-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 253357
     checksum: sha256:30ad5408417c7f06fb945dc321bef3ce31f813f25389707dd1efa7c1d337b806
     name: psmisc
     evr: 23.4-3.el9
     sourcerpm: psmisc-23.4-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-dnf-4.14.0-9.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 477657
-    checksum: sha256:a4973ead8c13cdf330e93f605e741814ac74c5212d964514e4088ad43fdcd5ff
+    size: 30481
+    checksum: sha256:65c73ac98cfbd459b1b9672da58f4e7cf89b6ad979717aa9912ebbed7242a944
+    name: python3
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-dnf-4.14.0-25.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 480011
+    checksum: sha256:85bdaa101978e4cc1ade26a6c3d024e221e21ee035f4274ebb8ecaa7ef0cd706
     name: python3-dnf
-    evr: 4.14.0-9.el9
-    sourcerpm: dnf-4.14.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-gpg-1.15.1-6.el9.x86_64.rpm
+    evr: 4.14.0-25.el9
+    sourcerpm: dnf-4.14.0-25.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-gpg-1.15.1-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 291563
     checksum: sha256:0fd96e53e678f92418c859d8fb95087dd989c7eacb399157768be0daef08cf8f
     name: python3-gpg
     evr: 1.15.1-6.el9
     sourcerpm: gpgme-1.15.1-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-hawkey-0.69.0-8.el9_4.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-hawkey-0.69.0-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 108267
-    checksum: sha256:5136d41af50ab5d689ee77402bd911b18bab878b371d706c32c3bab5424805e1
+    size: 107800
+    checksum: sha256:29471b28015f59dc95ffe2fd65c1e4d8a5cfba6e936757bef6291050420986f6
     name: python3-hawkey
-    evr: 0.69.0-8.el9_4.1
-    sourcerpm: libdnf-0.69.0-8.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-libcomps-0.1.18-1.el9.x86_64.rpm
+    evr: 0.69.0-13.el9
+    sourcerpm: libdnf-0.69.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libcomps-0.1.18-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 53345
     checksum: sha256:39d6fe73373ae5692e510b7c6219ad1ffadad0f1bc59cb7095faf6e095811768
     name: python3-libcomps
     evr: 0.1.18-1.el9
     sourcerpm: libcomps-0.1.18-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-libdnf-0.69.0-8.el9_4.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libdnf-0.69.0-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 801999
-    checksum: sha256:9427809bd5bebf1901941fda9cb11b67996141d745004a1cc7b6a6979d56be8b
+    size: 800686
+    checksum: sha256:331ce2bf00b96671e73e5889d98f38d46bf61d22c051d3634dae1e76ea49181f
     name: python3-libdnf
-    evr: 0.69.0-8.el9_4.1
-    sourcerpm: libdnf-0.69.0-8.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.2.3-8.el9.noarch.rpm
+    evr: 0.69.0-13.el9
+    sourcerpm: libdnf-0.69.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1182551
-    checksum: sha256:14411411738a6312e0419c55cba18610d1fc284e1b1b988f578cff5147462fb3
+    size: 8477687
+    checksum: sha256:7d1a15f4540d24ce9e3c17fbfa9850e1ce87c41993b94931a85f1fcfda7eefdd
+    name: python3-libs
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 1193706
+    checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
     name: python3-pip-wheel
-    evr: 21.2.3-8.el9
-    sourcerpm: python-pip-21.2.3-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-rpm-4.16.1.3-29.el9.x86_64.rpm
+    evr: 21.3.1-1.el9
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-rpm-4.16.1.3-37.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 70181
-    checksum: sha256:dd04ca1be5f4812281386b26a4443db62f6aa8da20797128b19a7b25670c76b2
+    size: 69939
+    checksum: sha256:f33881afbad42a5ef4b8f592fa02d674a68f8ea906eaa0045d73af7fb3a927f3
     name: python3-rpm
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-12.el9_4.1.noarch.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 480119
-    checksum: sha256:81c47e6a77e1e4e349e13366898ba59d2c7898e844067f3430d8740de2748c61
+    size: 480100
+    checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
     name: python3-setuptools-wheel
-    evr: 53.0.0-12.el9_4.1
-    sourcerpm: python-setuptools-53.0.0-12.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/r/rdma-core-48.0-1.el9.x86_64.rpm
+    evr: 53.0.0-13.el9
+    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/r/rdma-core-54.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 63871
-    checksum: sha256:30b327f17f401ecd7ac6a782ae32632eae90cbf4f5cfef4ba82879a56d028e30
+    size: 67757
+    checksum: sha256:98cc2151f7e78c79ccadea0582c08f9648616699f8b32eb6fe14def9c15878bd
     name: rdma-core
-    evr: 48.0-1.el9
-    sourcerpm: rdma-core-48.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/r/rpm-build-libs-4.16.1.3-29.el9.x86_64.rpm
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/r/rpm-build-libs-4.16.1.3-37.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 92465
-    checksum: sha256:a25cb2f8958f2559e476d5d863d61ebc9851cb04ec0311cc14fb138f3c44a78f
+    size: 92449
+    checksum: sha256:b98fbdc053c915848bedb008aa93127efc64192359aba59fd094d245fba7e4a0
     name: rpm-build-libs
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/r/rpm-sign-libs-4.16.1.3-29.el9.x86_64.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/r/rpm-sign-libs-4.16.1.3-37.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 22598
-    checksum: sha256:12aae7199cd4b7e92bf2a66a39a191fc6ad7c907b301366e5eb77d354acd700f
+    size: 22416
+    checksum: sha256:98b7dbb2711f41e4c55612a4e6e03f17a59a8e98df866ff644b9c85620aff0d0
     name: rpm-sign-libs
-    evr: 4.16.1.3-29.el9
-    sourcerpm: rpm-4.16.1.3-29.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/s/systemd-252-32.el9_4.7.x86_64.rpm
+    evr: 4.16.1.3-37.el9
+    sourcerpm: rpm-4.16.1.3-37.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/r/rsync-3.2.5-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4405104
-    checksum: sha256:46c294f00ff7f4f617d301238ea711e38f7f66b98a23e716a94cc32b4a638e68
+    size: 421930
+    checksum: sha256:b1d90c38b613f2d66dfe0c7c3d067a3ce429f7b2ec5224e560f326fc2fd8d1e5
+    name: rsync
+    evr: 3.2.5-3.el9
+    sourcerpm: rsync-3.2.5-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-252-51.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 4425249
+    checksum: sha256:7bd22f7b3872de16d5b6dfd95051c7bd7bccecc0e2216093c3f82cf4a96275ce
     name: systemd
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/s/systemd-pam-252-32.el9_4.7.x86_64.rpm
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-pam-252-51.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 289236
-    checksum: sha256:11b5976c85a098b0a06e47094c54c0f0cb7ca27009c798012b55fd95f2f4bbaa
+    size: 294725
+    checksum: sha256:4bf47b8480375f5972ccd826a8bf51700df22bc2a7767daa81e1d50366e64ea2
     name: systemd-pam
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-32.el9_4.7.noarch.rpm
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 72883
-    checksum: sha256:27dfee433fe47cd843c8e610428f5167b1b12bc03e2bc831bca27dee15aadaf1
+    size: 77716
+    checksum: sha256:3cbe727507a7bc53773cd360372d7be3876f8ddf29b0181158c7f250caa3331c
     name: systemd-rpm-macros
-    evr: 252-32.el9_4.7
-    sourcerpm: systemd-252-32.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/t/tar-1.34-6.el9_4.1.x86_64.rpm
+    evr: 252-51.el9
+    sourcerpm: systemd-252-51.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/t/tar-1.34-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 910343
-    checksum: sha256:76f2f5fd1f37153d51a697659db31bd2a672a1a4536b42ce020cf9602ea3cde7
+    size: 910235
+    checksum: sha256:17f2e592a2c04c050b690afeb9042e02521a0b5ee3288dad837463f4acf542c3
     name: tar
-    evr: 2:1.34-6.el9_4.1
-    sourcerpm: tar-1.34-6.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
+    evr: 2:1.34-7.el9
+    sourcerpm: tar-1.34-7.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1152092
     checksum: sha256:2062dce4bed26d3684de4dad68f32307ebacf5c7d50d3aa7bf6470e66fb36df5
     name: tcl
     evr: 1:8.6.10-7.el9
     sourcerpm: tcl-8.6.10-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.2-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 618904
-    checksum: sha256:b3b8e36af06df2dc64a71f767746165538367e4ef8dd2ef79404855c016d2b06
+    size: 621714
+    checksum: sha256:b1f148136e6cf67ac5f86a601d41a1b2798e7b5ef32e684358987d77c9ed424b
     name: tpm2-tss
-    evr: 3.2.2-2.el9
-    sourcerpm: tpm2-tss-3.2.2-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/u/unzip-6.0-56.el9.x86_64.rpm
+    evr: 3.2.3-1.el9
+    sourcerpm: tpm2-tss-3.2.3-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/unzip-6.0-58.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 190864
-    checksum: sha256:8bffcefdc923297e695f4747b8047c9cfdb6e645104b3f2b2a4679255e3b33e8
+    size: 190785
+    checksum: sha256:009698f3b4432b9df219fd2f894234aad1cee8c4e4e61384b4e293ef8e28e9c2
     name: unzip
-    evr: 6.0-56.el9
-    sourcerpm: unzip-6.0-56.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/u/util-linux-2.37.4-18.el9.x86_64.rpm
+    evr: 6.0-58.el9_5
+    sourcerpm: unzip-6.0-58.el9_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/util-linux-2.37.4-21.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2396787
-    checksum: sha256:8f6d909c7fe1cddfe9e9f57333380b9cc700925e5713d682447456580ff96352
+    size: 2395065
+    checksum: sha256:61c795084ae4b7745b904347d4643110cd62558fce2978bd4f025ff83524e55f
     name: util-linux
-    evr: 2.37.4-18.el9
-    sourcerpm: util-linux-2.37.4-18.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-18.el9.x86_64.rpm
+    evr: 2.37.4-21.el9
+    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-21.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 480160
-    checksum: sha256:f344470b51f9cfdbc499b134c6d5d399f4011cec5250525f233de2d4199bf25e
+    size: 480619
+    checksum: sha256:36389814fcec56d9b9d4bd1a4a63efb1cefa00bc8bacab73f89ef8f8be04b1cd
     name: util-linux-core
-    evr: 2.37.4-18.el9
-    sourcerpm: util-linux-2.37.4-18.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-20.el9_1.noarch.rpm
+    evr: 2.37.4-21.el9
+    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-22.el9_6.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 22428
-    checksum: sha256:6f0dbb5a2c675b932a0eb650c83b68eb485e02808b02bb27373eef30a283f5bc
+    size: 17723
+    checksum: sha256:744aceed764a5a4f5e4f12a70237ff74cb93c375aabffe4dc245e474628775c2
     name: vim-filesystem
-    evr: 2:8.2.2637-20.el9_1
-    sourcerpm: vim-8.2.2637-20.el9_1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
+    evr: 2:8.2.2637-22.el9_6
+    sourcerpm: vim-8.2.2637-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 235693
     checksum: sha256:f16d17c26a241400586ddc3d734ce863e3f19d433881ec640a47bedf0dafd07b
     name: xz
     evr: 5.2.5-8.el9_0
     sourcerpm: xz-5.2.5-8.el9_0.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/y/yum-4.14.0-9.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/y/yum-4.14.0-25.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 94730
-    checksum: sha256:f2d142cfaa1a2074fd0971181ebcd3832e425a3a58042e86bfa6bcc95a46301f
+    size: 93904
+    checksum: sha256:cf8b191674efee22dc2f01e8932a6edc26f9ec2fdcc1f1cbe303b06d1958d439
     name: yum
-    evr: 4.14.0-9.el9
-    sourcerpm: dnf-4.14.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/codeready-builder/os/Packages/l/libarchive-devel-3.5.3-4.el9.x86_64.rpm
-    repoid: codeready-builder-for-rhel-9-x86_64-rpms
-    size: 138653
-    checksum: sha256:9bb8330d80109adcd2f6049cc376bdce41d330982ccd07c19f0e97641c21edd7
-    name: libarchive-devel
-    evr: 3.5.3-4.el9
-    sourcerpm: libarchive-3.5.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/c/cpp-11.4.1-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 11143019
-    checksum: sha256:f4535a6a48a126be6134fdce68c1f41cece00f67208c2314b9ed24052457e056
-    name: cpp
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/d/dpdk-23.11-2.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3886825
-    checksum: sha256:7ab35a7bc669fe7be878668e66ea839a50aec748cd78b106423dedc10f5bd57a
-    name: dpdk
-    evr: 2:23.11-2.el9_4
-    sourcerpm: dpdk-23.11-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/d/dpdk-devel-23.11-2.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4378823
-    checksum: sha256:a77d872ff78e2794ccb6495391170edeecba92d830cbaf62f1f71a2b70ea77ce
-    name: dpdk-devel
-    evr: 2:23.11-2.el9_4
-    sourcerpm: dpdk-23.11-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/d/dpdk-tools-23.11-2.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 30076
-    checksum: sha256:47831f993fa6acef393c7575862ee329e33e2c10666aa98cdf39f054a55986e1
-    name: dpdk-tools
-    evr: 2:23.11-2.el9_4
-    sourcerpm: dpdk-23.11-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/e/emacs-filesystem-27.2-10.el9_4.2.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 8564
-    checksum: sha256:531d6b7ebe0141d525c89b849c06dce4466de6c44c6811216cf048369d30acfa
-    name: emacs-filesystem
-    evr: 1:27.2-10.el9_4.2
-    sourcerpm: emacs-27.2-10.el9_4.2.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/gcc-11.4.1-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 33794491
-    checksum: sha256:eb4f59b42086f57aa2c5d98e70d14bfdc468e374fb9e3cfeb8047522337c2ec4
-    name: gcc
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/git-2.43.5-1.el9_4.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 51765
-    checksum: sha256:6e4b1f14afecec2bf0eb506eaf6412beb9d9269dfabfa17c79ece9c3474c1394
-    name: git
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/git-core-2.43.5-1.el9_4.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4647661
-    checksum: sha256:3674abe07d8a5aa2b5dfc1b887bc03dedf316fad27122da0699d8acc4678fea4
-    name: git-core
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/git-core-doc-2.43.5-1.el9_4.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 3075181
-    checksum: sha256:7a1fbab9fe6b7e6de67b7d1e1ec10c985396e60001e3a9cf8015f4470716bb94
-    name: git-core-doc
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/glibc-devel-2.34-100.el9_4.10.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 30195
-    checksum: sha256:2623340047050bccbbd235ba4376485471595834d6459285d2ad8773b7a9542c
-    name: glibc-devel
-    evr: 2.34-100.el9_4.10
-    sourcerpm: glibc-2.34-100.el9_4.10.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/glibc-headers-2.34-100.el9_4.10.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 548006
-    checksum: sha256:48757d467ae06c84cc517910caf38d4aba1847d69e9ec08af70d888a7f77151f
-    name: glibc-headers
-    evr: 2.34-100.el9_4.10
-    sourcerpm: glibc-2.34-100.el9_4.10.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/glibc-locale-source-2.34-100.el9_4.10.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4354995
-    checksum: sha256:f43fd69b789c45b0366a305f418310d6116d7c2536628294be8ff6fdf45db6f4
-    name: glibc-locale-source
-    evr: 2.34-100.el9_4.10
-    sourcerpm: glibc-2.34-100.el9_4.10.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-427.68.2.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 4516713
-    checksum: sha256:2c89ad34eeb3e5ed3145d0fc547398b4eecf710c0d62c36bbcb1df3643a10361
-    name: kernel-headers
-    evr: 5.14.0-427.68.2.el9_4
-    sourcerpm: kernel-5.14.0-427.68.2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/p/perl-Git-2.43.5-1.el9_4.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 38619
-    checksum: sha256:a69b55fef7675e204d88435984c4443d34b7964dfc8e06d1bbce355b8dcf5efa
-    name: perl-Git
-    evr: 2.43.5-1.el9_4.1
-    sourcerpm: git-2.43.5-1.el9_4.1.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.18-3.el9_4.7.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 10336
-    checksum: sha256:0422c5e81b216b5bbcffde24ae94e653cf95df5c4bc4f6507b77e12bfebe5b3b
-    name: python-unversioned-command
-    evr: 3.9.18-3.el9_4.7
-    sourcerpm: python3.9-3.9.18-3.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/e/expat-2.5.0-2.el9_4.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 121758
-    checksum: sha256:c2ecc3952f21977c3f6158e12c3c75264f9c637b7f6dd3e3ac4e75b19ebc6faf
-    name: expat
-    evr: 2.5.0-2.el9_4.2
-    sourcerpm: expat-2.5.0-2.el9_4.2.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/l/libgomp-11.4.1-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 266308
-    checksum: sha256:939af21eab791b0384b33a9bb136b642188fa04f7989bfd01b2ef94a91f3475c
-    name: libgomp
-    evr: 11.4.1-4.el9_4
-    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/o/openssh-8.7p1-38.el9_4.5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 474293
-    checksum: sha256:44c59d9397cfa395e146155a01fdb0fc5b9e87d597a9a9b9fc5fe345a5b46b67
-    name: openssh
-    evr: 8.7p1-38.el9_4.5
-    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-38.el9_4.5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 736808
-    checksum: sha256:3897e45c11ee0c6d9a5ca3d5f02bfa45187aae4628737244d1da73446b29dc14
-    name: openssh-clients
-    evr: 8.7p1-38.el9_4.5
-    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/o/openssl-3.0.7-29.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 1265961
-    checksum: sha256:aa92fbd2ebf2087b784857f1daa6f1fe665b0a50bf73d777943cae487fcf6072
-    name: openssl
-    evr: 1:3.0.7-29.el9_4
-    sourcerpm: openssl-3.0.7-29.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/p/pam-1.5.1-23.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 647182
-    checksum: sha256:b2a90a84512ccf6acd4a16d48c65b689fd5e44bd545231dffdb8525d783beb94
-    name: pam
-    evr: 1.5.1-23.el9_4
-    sourcerpm: pam-1.5.1-23.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-3.9.18-3.el9_4.7.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 30294
-    checksum: sha256:843893abd4e5219901ac740c0513c1b575562183222adee7ea92fc63ab73072a
-    name: python3
-    evr: 3.9.18-3.el9_4.7
-    sourcerpm: python3.9-3.9.18-3.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/p/python3-libs-3.9.18-3.el9_4.7.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 8233004
-    checksum: sha256:5479683380a975504f825212fe8c221ad5a7b8f1cc11095eaaf5d244144c5d43
-    name: python3-libs
-    evr: 3.9.18-3.el9_4.7
-    sourcerpm: python3.9-3.9.18-3.el9_4.7.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/r/rsync-3.2.3-19.el9_4.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
-    size: 409798
-    checksum: sha256:9202697f872c6bce4e3be7ed61eaa15fc48bf76673ce8f3a48fe94c414a5f783
-    name: rsync
-    evr: 3.2.3-19.el9_4.1
-    sourcerpm: rsync-3.2.3-19.el9_4.1.src.rpm
+    evr: 4.14.0-25.el9
+    sourcerpm: dnf-4.14.0-25.el9.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
OCP 4.20+ is RHEL 9.6 based