### PR TITLE
Fix PLATFORM and pin DPDK to 23.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV \
     # The $HOME is not set by default, but some applications needs this variable
     HOME=/opt/app-root/src \
     PATH=$PATH:/opt/app-root/src/bin:/opt/app-root/bin \
-    PLATFORM="el9"
+    PLATFORM="el8"
 
 ENV BUILDER_VERSION 0.1
 ENV DPDK_VER 23.11-1
@@ -38,9 +38,9 @@ RUN INSTALL_PKGS="bsdtar \
   unzip \
   xz \
   yum \
-  dpdk \
-  dpdk-devel \
-  dpdk-tools \
+  dpdk-23.11 \
+  dpdk-devel-23.11 \
+  dpdk-tools-23.11 \
   make \
   rdma-core \
   libibverbs \


### PR DESCRIPTION
RHEL 8 AppStream offers both 21.11 and 23.11. Let's be explicit about which version is desired, otherwise DNF may decide arbitrarily to pick one over the other.