### PR TITLE
Add the which package for dpdk-devbind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN INSTALL_PKGS="bsdtar \
   libibverbs \
   git \
   gcc \
+  which \
   expect" && \
   mkdir -p ${HOME}/.pki/nssdb && \
   chown -R 1001:0 ${HOME}/.pki && \

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -60,6 +60,7 @@ packages:
   - libibverbs
   - git
   - gcc
+  - which
   - expect
 
 arches:

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1194,6 +1194,13 @@ arches:
     name: vim-filesystem
     evr: 2:8.2.2637-22.el9_6
     sourcerpm: vim-8.2.2637-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/w/which-2.21-29.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 45104
+    checksum: sha256:61eef3ee2dcd3d2e3b784464e801cbea2e8e668271b4aff97529110b45915191
+    name: which
+    evr: 2.21-29.el9
+    sourcerpm: which-2.21-29.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 235798
@@ -2430,6 +2437,13 @@ arches:
     name: vim-filesystem
     evr: 2:8.2.2637-22.el9_6
     sourcerpm: vim-8.2.2637-22.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/w/which-2.21-29.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45737
+    checksum: sha256:ecfb8a10701375e0f7936825c920113842d63537f1994d915e7f77ec271d2ffb
+    name: which
+    evr: 2.21-29.el9
+    sourcerpm: which-2.21-29.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/x/xz-5.2.5-8.el9_0.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 235693


### PR DESCRIPTION
Without the which package we run into this error:

sh-4.4# dpdk-devbind.py --status
Traceback (most recent call last):
  File "/usr/bin/dpdk-devbind.py", line 748, in <module>
    main()
  File "/usr/bin/dpdk-devbind.py", line 731, in main
    stdout=devnull, stderr=devnull)
  File "/usr/lib64/python3.6/subprocess.py", line 287, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib64/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib64/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'which': 'which' sh-4.4#