### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for dpdk-base-4-12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.redhat.io/rhel8-6-els/rhel:8.6
 
 LABEL com.redhat.component="dpdk-base-container" \
-    name="dpdk-base" \
+    name="openshift4/dpdk-base-rhel8" \
+    cpe="cpe:/a:redhat:openshift:4.12::el8" \
     version="${CI_CONTAINER_VERSION}" \
     summary="dpdk-base" \
     io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
