### PR TITLE
Migrate off 'rpm' manager for 'rpm-lockfile'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,20 +4,7 @@
     "automergeType": "pr",
     "prConcurrentLimit": 0,
     "pruneBranchAfterAutomerge": true,
-    "rpm": {
-        "autoApprove": true,
-        "enabled": true,
-        "ignoreTests": false,
-        "includePaths": ["rpms.lock.yaml"],
-	"packageRules": [
-          {
-            "matchUpdateTypes": ["minor", "patch"],
-            "automerge": true,
-            "addLabels": ["lgtm", "approved"]
-          }
-        ],
-        "platformAutomerge": true
-    },
+    "rpmVulnerabilityAutomerge": "ALL",
     "tekton": {
         "autoApprove": true,
         "automerge": true,


### PR DESCRIPTION
The 'rpm' package manager has been decommissioned. Use the new approach for RPM remediation in MintMaker.