### PR TITLE
Branch cut for release 5.0

### DIFF
--- a/.tekton/dpdk-base-5-0-pull-request.yaml
+++ b/.tekton/dpdk-base-5-0-pull-request.yaml
@@ -11,10 +11,10 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: dpdk-base-4-22
-    appstudio.openshift.io/component: dpdk-base-4-22
+    appstudio.openshift.io/application: dpdk-base-5-0
+    appstudio.openshift.io/component: dpdk-base-5-0
     pipelines.appstudio.openshift.io/type: build
-  name: dpdk-base-4-22-on-pull-request
+  name: dpdk-base-5-0-on-pull-request
   namespace: telco-5g-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/dpdk-base-4-22:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/dpdk-base-5-0:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -617,7 +617,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-dpdk-base-4-22
+    serviceAccountName: build-pipeline-dpdk-base-5-0
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/dpdk-base-5-0-push.yaml
+++ b/.tekton/dpdk-base-5-0-push.yaml
@@ -10,10 +10,10 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: dpdk-base-4-22
-    appstudio.openshift.io/component: dpdk-base-4-22
+    appstudio.openshift.io/application: dpdk-base-5-0
+    appstudio.openshift.io/component: dpdk-base-5-0
     pipelines.appstudio.openshift.io/type: build
-  name: dpdk-base-4-22-on-push
+  name: dpdk-base-5-0-on-push
   namespace: telco-5g-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/dpdk-base-4-22:{{revision}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/dpdk-base-5-0:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -605,7 +605,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-dpdk-base-4-22
+    serviceAccountName: build-pipeline-dpdk-base-5-0
   workspaces:
   - name: git-auth
     secret:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:fe688da81a696387c
 
 LABEL com.redhat.component="dpdk-base-container" \
     name="openshift4/dpdk-base-rhel9" \
-    cpe="cpe:/a:redhat:openshift:4.22::el9" \
+    cpe="cpe:/a:redhat:openshift:5.0::el9" \
     version="${CI_CONTAINER_VERSION}" \
     summary="dpdk-base" \
     io.openshift.expose-services="" \


### PR DESCRIPTION
Update Tekton pipelines and Dockerfile for the 5.0 release branch. Replace dpdk-base-4-22 pipeline definitions with dpdk-base-5-0.

Made-with: Cursor